### PR TITLE
Read config from package.json

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -120,10 +120,10 @@ async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Pr
                         await processError(server, pluginConfig, `File ${jsonFileName} is not valid JSON`)
                         return false
                     }
-                    if (configUpdate['posthog-plugin-config']) {
-                        // plugin.json has `config`, but in package.json we prefer `posthog-plugin-config` for clarity
-                        configUpdate.config = configUpdate['posthog-plugin-config']
-                        delete configUpdate['posthog-plugin-config']
+                    if (configUpdate['configSchema']) {
+                        // plugin.json has `config`, but in package.json we prefer `configSchema`
+                        configUpdate.config = configUpdate['configSchema']
+                        delete configUpdate['configSchema']
                     }
                     if (configUpdate.homepage) {
                         // plugin.json has `url`, but in package.json we prefer the conventional `homepage`

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -117,12 +117,18 @@ async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Pr
                     try {
                         configUpdate = JSON.parse(rawConfigUpdate)
                     } catch {
-                        await processError(server, pluginConfig, `File ${jsonFileName} contains is not valid JSON`)
+                        await processError(server, pluginConfig, `File ${jsonFileName} is not valid JSON`)
                         return false
                     }
-                    if (!configUpdate.config && configUpdate['posthog-plugin-config']) {
+                    if (configUpdate['posthog-plugin-config']) {
+                        // plugin.json has `config`, but in package.json we prefer `posthog-plugin-config` for clarity
                         configUpdate.config = configUpdate['posthog-plugin-config']
                         delete configUpdate['posthog-plugin-config']
+                    }
+                    if (configUpdate.homepage) {
+                        // plugin.json has `url`, but in package.json we prefer the conventional `homepage`
+                        configUpdate.url = configUpdate.homepage
+                        delete configUpdate['homepage']
                     }
                     config = { ...config, ...configUpdate }
                     wasConfigLoaded = true

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -213,7 +213,7 @@ test('local plugin with broken plugin.json does not do much', async () => {
 
     expect(setError).toHaveBeenCalled()
     expect(setError.mock.calls[0][0]).toEqual(mockServer)
-    expect(setError.mock.calls[0][1]!.message).toContain('Could not load posthog config at ')
+    expect(setError.mock.calls[0][1]!.message).toContain('File plugin.json is not valid JSON')
     expect(setError.mock.calls[0][1]!.time).toBeDefined()
     expect(pluginConfigs.get(39)!.vm).toEqual(null)
 


### PR DESCRIPTION
This resolves #13. Adds support for `package.json`-based configs (_preferably_ with ~~`posthog-plugin-config`~~ `configSchema` instead of `config` and with conventional `homepage` instead of `url`), while making no breaking changes.