### PR TITLE
Github Actions: Skip db init if no new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,7 @@ jobs:
               run: yarn --frozen-lockfile
 
             - name: Initiate database for tests
+              if: steps.version.outputs.IS_NEW_VERSION == 'true'
               env:
                   DATABASE_URL: 'postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres'
                   REDIS_URL: 'redis://localhost'


### PR DESCRIPTION
## Changes

I tend to get this on every merge:

![image](https://user-images.githubusercontent.com/53387/104513757-76e28200-55f0-11eb-8782-19c133d3c4c3.png)


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
