### PR TITLE
Reorder plugins per team based on `order`

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -83,14 +83,16 @@ export async function setupPlugins(server: PluginsServer): Promise<void> {
         }
     }
 
-    if (server.defaultConfigs.length > 0) {
-        server.defaultConfigs.sort((a, b) => a.order - b.order)
-        for (const teamId of Object.keys(server.pluginConfigsPerTeam).map((key: string) => parseInt(key))) {
-            server.pluginConfigsPerTeam.set(teamId, [
+    const sortFunction = (a: PluginConfig, b: PluginConfig) => (a.order || 0) - (b.order || 0)
+    for (const teamId of server.pluginConfigsPerTeam.keys()) {
+        if (server.defaultConfigs.length > 0) {
+            const combinedPluginConfigs = [
                 ...(server.pluginConfigsPerTeam.get(teamId) || []),
                 ...server.defaultConfigs,
-            ])
-            server.pluginConfigsPerTeam.get(teamId)?.sort((a, b) => a.id - b.id)
+            ].sort(sortFunction)
+            server.pluginConfigsPerTeam.set(teamId, combinedPluginConfigs)
+        } else {
+            server.pluginConfigsPerTeam.get(teamId)?.sort(sortFunction)
         }
     }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -83,7 +83,7 @@ export async function setupPlugins(server: PluginsServer): Promise<void> {
         }
     }
 
-    const sortFunction = (a: PluginConfig, b: PluginConfig) => (a.order || 0) - (b.order || 0)
+    const sortFunction = (a: PluginConfig, b: PluginConfig) => a.order - b.order
     for (const teamId of server.pluginConfigsPerTeam.keys()) {
         if (server.defaultConfigs.length > 0) {
             const combinedPluginConfigs = [

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -40,6 +40,7 @@ export async function resetTestDatabase(code: string): Promise<void> {
             session_recording_opt_in: true,
             plugins_opt_in: true,
             opt_out_capture: false,
+            is_demo: false,
         })
     }
     for (const plugin of mocks.pluginRows) {


### PR DESCRIPTION
## Changes

- Takes the `order` of plugins into account per team
- Still keeps support for the `defaultConfigs`, though we might just remove that in the future.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
