### PR TITLE
Catch inside Kafka eachBatch

### DIFF
--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -94,7 +94,14 @@ export class KafkaQueue implements Queue {
                 eachBatchAutoResolve: false, // we are resolving the last offset of the batch more deliberately
                 autoCommitInterval: 500, // autocommit every 500 ms…
                 autoCommitThreshold: 1000, // …or every 1000 messages, whichever is sooner
-                eachBatch: this.eachBatch.bind(this),
+                eachBatch: async (payload) => {
+                    try {
+                        await this.eachBatch(payload)
+                    } catch (error) {
+                        Sentry.captureException(error)
+                        throw error
+                    }
+                },
             })
         })
         return await startPromise


### PR DESCRIPTION
## Changes

This should hopefully give us better errors than `KafkaJSNumberOfRetriesExceeded` 

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
