### PR TITLE
Remove steps to publish to github registry

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -113,16 +113,3 @@ jobs:
               with:
                   tag_name: ${{ env.PACKAGE_VERSION_TAG }}
                   release_name: ${{ env.PACKAGE_VERSION }}
-
-            - name: Switch to the GitHub registry
-              if: steps.version.outputs.IS_NEW_VERSION == 'true'
-              uses: actions/setup-node@v2
-              with:
-                  node-version: 14
-                  registry-url: https://npm.pkg.github.com
-
-            - name: Publish the package in the GitHub registry
-              if: steps.version.outputs.IS_NEW_VERSION == 'true'
-              run: npm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

This has never worked since switching to `@posthog/` and we don't want *another* place we want to maintain and keep up to date. So removing.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
