### PR TITLE
Add second-precision timestamp for updating persons in clickhouse

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -152,7 +152,7 @@ export class DB {
                     } else if (typeof value === 'boolean') {
                         clickhouseValue = value ? '1' : '0'
                     } else if (DateTime.isDateTime(value)) {
-                        clickhouseValue = castTimestampOrNow(value, TimestampFormat.ClickHouse)
+                        clickhouseValue = castTimestampOrNow(value, TimestampFormat.ClickHouseSecondPrecision)
                     } else {
                         clickhouseValue = JSON.stringify(value)
                     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,6 +338,7 @@ export interface PostgresSessionRecordingEvent extends Omit<SessionRecordingEven
 }
 
 export enum TimestampFormat {
+    ClickHouseSecondPrecision = 'clickhouse-second-precision',
     ClickHouse = 'clickhouse',
     ISO = 'iso',
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -302,7 +302,9 @@ export function castTimestampOrNow(
         timestamp = DateTime.fromISO(timestamp)
     }
     timestamp = timestamp.toUTC()
-    if (timestampFormat === TimestampFormat.ClickHouse) {
+    if (timestampFormat === TimestampFormat.ClickHouseSecondPrecision) {
+        return timestamp.toFormat('yyyy-MM-dd HH:mm:ss')
+    } else if (timestampFormat === TimestampFormat.ClickHouse) {
         return timestamp.toFormat('yyyy-MM-dd HH:mm:ss.u')
     } else if (timestampFormat === TimestampFormat.ISO) {
         return timestamp.toUTC().toISO()


### PR DESCRIPTION
## Changes

- To fix https://sentry.io/organizations/posthog/issues/2202614650/?project=5592816&query=is%3Aunresolved

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
