### PR TITLE
Silence logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-server",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "PostHog Plugin Server",
     "types": "dist/src/index.d.ts",
     "main": "dist/src/index.js",

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,8 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import * as Sentry from '@sentry/node'
 
 import { setError } from './sql'
-import { status } from './status'
 import { PluginConfig, PluginConfigId, PluginError, PluginsServer } from './types'
 
 export async function processError(
@@ -11,9 +9,6 @@ export async function processError(
     error: Error | string,
     event?: PluginEvent | null
 ): Promise<void> {
-    Sentry.captureException(error)
-    status.error('⁉️', 'An error occurred:\n', error)
-
     const errorJson: PluginError =
         typeof error === 'string'
             ? {

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -5,6 +5,7 @@ import { PluginsServer, Queue, RawEventMessage } from 'types'
 
 import { status } from '../status'
 import { killGracefully, runInParallelBatches } from '../utils'
+import { timeoutGuard } from './utils'
 
 export class KafkaQueue implements Queue {
     private pluginsServer: PluginsServer
@@ -60,12 +61,21 @@ export class KafkaQueue implements Queue {
                 )
             )
         )
+
+        const processingTimeout = timeoutGuard(
+            `Took too long to run plugins on ${pluginEvents.length} events! Timeout after 30 sec!`
+        )
         const processedEvents = await runInParallelBatches(pluginEvents, maxBatchSize, this.processEventBatch)
+        window.clearTimeout(processingTimeout)
 
         // Sort in the original order that the events came in, putting any randomly added events to the end.
         // This is so we would resolve the correct kafka offsets in order.
         processedEvents.sort(
             (a, b) => (uuidOrder.get(a.uuid!) || pluginEvents.length) - (uuidOrder.get(b.uuid!) || pluginEvents.length)
+        )
+
+        const ingestionTimeout = timeoutGuard(
+            `Took too long to ingest ${processedEvents.length} events! Timeout after 30 sec!`
         )
 
         // TODO: add chunking into groups of 500 or so. Might start too many promises at once now
@@ -98,6 +108,9 @@ export class KafkaQueue implements Queue {
                 this.pluginsServer.statsd?.timing('kafka_queue.single_ingestion', singleIngestionTimer)
             }
         }
+
+        window.clearTimeout(ingestionTimeout)
+
         this.pluginsServer.statsd?.timing('kafka_queue.each_batch', batchProcessingTimer)
         resolveOffset(batch.lastOffset())
         await heartbeat()

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -66,7 +66,7 @@ export class KafkaQueue implements Queue {
             `Took too long to run plugins on ${pluginEvents.length} events! Timeout after 30 sec!`
         )
         const processedEvents = await runInParallelBatches(pluginEvents, maxBatchSize, this.processEventBatch)
-        window.clearTimeout(processingTimeout)
+        clearTimeout(processingTimeout)
 
         // Sort in the original order that the events came in, putting any randomly added events to the end.
         // This is so we would resolve the correct kafka offsets in order.
@@ -109,7 +109,7 @@ export class KafkaQueue implements Queue {
             }
         }
 
-        window.clearTimeout(ingestionTimeout)
+        clearTimeout(ingestionTimeout)
 
         this.pluginsServer.statsd?.timing('kafka_queue.each_batch', batchProcessingTimer)
         resolveOffset(batch.lastOffset())

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -3,6 +3,7 @@ import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import { Producer } from 'kafkajs'
 import { DateTime, Duration } from 'luxon'
+import * as fetch from 'node-fetch'
 import { nodePostHog } from 'posthog-js-lite/dist/src/targets/node'
 
 import Client from '../celery/client'
@@ -38,7 +39,7 @@ export class EventsProcessor {
         this.clickhouse = pluginsServer.clickhouse!
         this.kafkaProducer = pluginsServer.kafkaProducer!
         this.celery = new Client(pluginsServer.redis, pluginsServer.CELERY_DEFAULT_QUEUE)
-        this.posthog = nodePostHog('sTMFPsFhdP1Ssg')
+        this.posthog = nodePostHog('sTMFPsFhdP1Ssg', { fetch })
         if (process.env.NODE_ENV === 'test') {
             this.posthog.optOut()
         }

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -334,6 +334,10 @@ export class EventsProcessor {
         const teamQueryResult = await this.db.postgresQuery('SELECT * FROM posthog_team WHERE id = $1', [teamId])
         const team: Team = teamQueryResult.rows[0]
 
+        if (!team) {
+            throw new Error(`No team found with ID ${teamId}. Can't ingest event.`)
+        }
+
         if (!team.anonymize_ips && !('$ip' in properties)) {
             properties['$ip'] = ip
         }

--- a/src/ingestion/utils.ts
+++ b/src/ingestion/utils.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node'
 import crypto from 'crypto'
 
 import { BasePerson, Element, Person, RawPerson } from '../types'
-import Timeout = NodeJS.Timeout
 
 export function unparsePersonPartial(person: Partial<Person>): Partial<RawPerson> {
     return { ...(person as BasePerson), ...(person.created_at ? { created_at: person.created_at.toISO() } : {}) }
@@ -157,7 +156,7 @@ export function chainToElements(chain: string): Element[] {
     return elements
 }
 
-export function timeoutGuard(message: string): Timeout {
+export function timeoutGuard(message: string): NodeJS.Timeout {
     return setTimeout(() => {
         console.log(`⌛⌛⌛ ${message}`)
         Sentry.captureMessage(message)

--- a/src/ingestion/utils.ts
+++ b/src/ingestion/utils.ts
@@ -1,6 +1,8 @@
+import * as Sentry from '@sentry/node'
 import crypto from 'crypto'
 
 import { BasePerson, Element, Person, RawPerson } from '../types'
+import Timeout = NodeJS.Timeout
 
 export function unparsePersonPartial(person: Partial<Person>): Partial<RawPerson> {
     return { ...(person as BasePerson), ...(person.created_at ? { created_at: person.created_at.toISO() } : {}) }
@@ -153,4 +155,11 @@ export function chainToElements(chain: string): Element[] {
         })
 
     return elements
+}
+
+export function timeoutGuard(message: string): Timeout {
+    return setTimeout(() => {
+        console.log(`⌛⌛⌛ ${message}`)
+        Sentry.captureMessage(message)
+    }, 30000)
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,7 +15,7 @@ export function initApp(config: PluginsServerConfig): void {
             dsn: config.SENTRY_DSN,
             // We recommend adjusting this value in production, or using tracesSampler for finer control
             tracesSampleRate: 1.0,
-            debug: true,
+            debug: false,
         })
     }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -226,7 +226,7 @@ export async function startPluginsServer(
         if (piscina) {
             await stopPiscina(piscina)
         }
-        await closeServer()
+        await closeServer?.()
 
         // wait an extra second for any misc async task to finish
         await delay(1000)


### PR DESCRIPTION
## Changes

- Silence runtime logs from within the plugin VMs (those are sent to postgres anyway)
- Remove sentry debug log
- Fix an issue with posthog-js-lite and some other small bugs
- Bump the version as well to `0.8.1` so that once merged, a new release is directly cut

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
