### PR TITLE
Add a bit of oldschool console logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "start": "yarn start:dev",
         "start:dist": "node dist/index.js --base-dir ../posthog",
         "start:dev": "ts-node-dev --exit-child src/index.ts --base-dir ../posthog",
-        "start:dev:ee": "KAFKA_ENABLED=true KAFKA_HOSTS=localhost:9092 yarn start:dev",
+        "start:dev:ee": "PLUGIN_SERVER_INGESTION=true KAFKA_ENABLED=true KAFKA_HOSTS=localhost:9092 yarn start:dev",
         "build": "yarn clean && yarn compile",
         "clean": "rimraf dist/*",
         "compile:protobuf": "cd src/idl/ && rimraf protos.* && pbjs -t static-module -w commonjs -o protos.js *.proto && pbts -o protos.d.ts protos.js && eslint --fix . && prettier --write .",

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -53,7 +53,7 @@ export class KafkaQueue implements Queue {
         })
 
         const maxBatchSize = Math.max(
-            1,
+            15,
             Math.min(
                 100,
                 Math.ceil(
@@ -143,6 +143,14 @@ export class KafkaQueue implements Queue {
         resolveOffset(batch.lastOffset())
         await heartbeat()
         await commitOffsetsIfNecessary()
+        status.info(
+            '🧩',
+            `Kafka Batch of ${batch.messages.length} events completed in ${
+                new Date().valueOf() - batchStartTimer.valueOf()
+            }ms (plugins: ${batchIngestionTimer.valueOf() - batchStartTimer.valueOf()}ms, ingestion: ${
+                new Date().valueOf() - batchIngestionTimer.valueOf()
+            }ms)`
+        )
     }
 
     async start(): Promise<void> {
@@ -161,6 +169,7 @@ export class KafkaQueue implements Queue {
                     try {
                         await this.eachBatch(payload)
                     } catch (error) {
+                        status.info('💀', `Kafka Batch of ${payload.batch.messages.length} events failed!`)
                         Sentry.captureException(error)
                         throw error
                     }


### PR DESCRIPTION
## Changes

Adding some of console logs to have better visibility into how things are going. Running a batch or two per second per server this shouldn't produce too much noise and can be dialled down later.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
