### PR TITLE
Prefilter Celery hooks task sending

### DIFF
--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -505,7 +505,7 @@ export class EventsProcessor {
             )
         }
 
-        if (this.shouldSendHooksTask(team)) {
+        if (await this.shouldSendHooksTask(team)) {
             this.celery.sendTask('ee.tasks.webhooks_ee.post_event_to_webhook_ee', [
                 {
                     event,

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -476,8 +476,8 @@ export class EventsProcessor {
         }
 
         let sendHookTask = !!team.slack_incoming_webhook
-        if (!sendHookTask && this.kafkaProducer) {
-            // Using kafkaProducer as proxy for EE being enabled
+        if (!sendHookTask && this.pluginsServer.KAFKA_ENABLED) {
+            // Using KAFKA_ENABLED as a proxy for running enterprise edition
             try {
                 const hookQueryResult = await this.db.postgresQuery(
                     `SELECT COUNT(*) FROM ee_hooks WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -442,8 +442,8 @@ export class EventsProcessor {
                     }
                 }
             }
-            this.pluginsServer.redis.set(hooksCacheKey, shouldSendHooksTask.toString())
-            this.pluginsServer.redis.expire(hooksCacheKey, 120)
+            await this.pluginsServer.redis.set(hooksCacheKey, shouldSendHooksTask.toString())
+            await this.pluginsServer.redis.expire(hooksCacheKey, 120)
         }
         return shouldSendHooksTask
     }

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -431,7 +431,7 @@ export class EventsProcessor {
                 // Using KAFKA_ENABLED as a proxy for running enterprise edition
                 try {
                     const hookQueryResult = await this.db.postgresQuery(
-                        `SELECT COUNT(*) FROM ee_hooks WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,
+                        `SELECT COUNT(*) FROM ee_hook WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,
                         [team.id]
                     )
                     shouldSendHooksTask = !!hookQueryResult.rows[0].count

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -476,7 +476,8 @@ export class EventsProcessor {
         }
 
         let sendHookTask = !!team.slack_incoming_webhook
-        if (!sendHookTask) {
+        if (!sendHookTask && this.kafkaProducer) {
+            // Using kafkaProducer as proxy for EE being enabled
             try {
                 const hookQueryResult = await this.db.postgresQuery(
                     `SELECT COUNT(*) FROM ee_hooks WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -437,7 +437,7 @@ export class EventsProcessor {
                     shouldSendHooksTask = !!hookQueryResult.rows[0].count
                 } catch (error) {
                     // In FOSS PostHog ee_hook does not exist. If the error is other than that, rethrow it
-                    if (String(error).includes('relation "ee_hook" does not exist')) {
+                    if (!String(error).includes('relation "ee_hook" does not exist')) {
                         throw error
                     }
                 }

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -443,7 +443,7 @@ export class EventsProcessor {
                 }
             }
             await this.pluginsServer.redis.set(hooksCacheKey, shouldSendHooksTask.toString())
-            await this.pluginsServer.redis.expire(hooksCacheKey, 120)
+            await this.pluginsServer.redis.expire(hooksCacheKey, 10)
         }
         return shouldSendHooksTask
     }

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -221,7 +221,7 @@ export const createProcessEventTests = (
         )
 
         if (database === 'clickhouse') {
-            expect(queryCounter).toBe(8)
+            expect(queryCounter).toBe(9)
         } else if (database === 'postgresql') {
             expect(queryCounter).toBe(12)
         }

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -128,6 +128,10 @@ export const createProcessEventTests = (
         processEventCounter = 0
         team = await getFirstTeam(server)
         now = DateTime.utc()
+
+        // clear the webhook redis cache
+        const hooksCacheKey = `@posthog/plugin-server/hooks/${team.id}`
+        await server.redis.del(hooksCacheKey)
     })
 
     afterEach(async () => {


### PR DESCRIPTION
## Changes

Similar to https://github.com/PostHog/posthog/pull/3368, this introduces better prefilter on sending the hook Celery task, to minimize Celery load.
Resolves #162.