### PR TITLE
Disable caching in `shouldSendHooksTask`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-server",
-    "version": "0.9.13",
+    "version": "0.9.14",
     "description": "PostHog Plugin Server",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -437,13 +437,16 @@ export class EventsProcessor {
     }
 
     private async shouldSendHooksTask(team: Team): Promise<boolean> {
+        if (team.slack_incoming_webhook) {
+            return true
+        }
+        if (!this.pluginsServer.KAFKA_ENABLED) {
+            return false
+        }
         const timeout = timeoutGuard(`Still running "shouldSendHooksTask". Timeout warning after 30 sec!`)
         try {
             const hookQueryResult = await this.db.postgresQuery(
-                `SELECT COUNT(*)
-                             FROM ee_hook
-                             WHERE team_id = $1
-                               AND event = 'action_performed' LIMIT 1`,
+                `SELECT COUNT(*) FROM ee_hook WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,
                 [team.id]
             )
             return !!hookQueryResult.rows[0].count

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -438,47 +438,24 @@ export class EventsProcessor {
 
     private async shouldSendHooksTask(team: Team): Promise<boolean> {
         const timeout = timeoutGuard(`Still running "shouldSendHooksTask". Timeout warning after 30 sec!`)
-        const hooksCacheKey = `@posthog/plugin-server/hooks/${team.id}`
-
-        const timeout2 = timeoutGuard(
-            `Still running "this.pluginsServer.redis.get(hooksCacheKey)". Timeout warning after 30 sec!`
-        )
-        const hooksCacheValue = await this.pluginsServer.redis.get(hooksCacheKey)
-        clearTimeout(timeout2)
-
-        let shouldSendHooksTask = false
-        if (hooksCacheValue) {
-            shouldSendHooksTask = hooksCacheValue === 'true'
-        } else {
-            if (team.slack_incoming_webhook) {
-                shouldSendHooksTask = true
-            } else if (this.pluginsServer.KAFKA_ENABLED) {
-                // Using KAFKA_ENABLED as a proxy for running enterprise edition
-                const timeout3 = timeoutGuard(`Still running "hook query". Timeout warning after 30 sec!`)
-                try {
-                    const hookQueryResult = await this.db.postgresQuery(
-                        `SELECT COUNT(*) FROM ee_hook WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,
-                        [team.id]
-                    )
-                    shouldSendHooksTask = !!hookQueryResult.rows[0].count
-                } catch (error) {
-                    status.info('🔔', error)
-                    // In FOSS PostHog ee_hook does not exist. If the error is other than that, rethrow it
-                    if (!String(error).includes('relation "ee_hook" does not exist')) {
-                        throw error
-                    }
-                } finally {
-                    clearTimeout(timeout)
-                    clearTimeout(timeout3)
-                }
+        try {
+            const hookQueryResult = await this.db.postgresQuery(
+                `SELECT COUNT(*)
+                             FROM ee_hook
+                             WHERE team_id = $1
+                               AND event = 'action_performed' LIMIT 1`,
+                [team.id]
+            )
+            return !!hookQueryResult.rows[0].count
+        } catch (error) {
+            // In FOSS PostHog ee_hook does not exist. If the error is other than that, rethrow it
+            if (!String(error).includes('relation "ee_hook" does not exist')) {
+                throw error
             }
-            const timeout4 = timeoutGuard(`Still running "redis set/expire". Timeout warning after 30 sec!`)
-            await this.pluginsServer.redis.set(hooksCacheKey, shouldSendHooksTask.toString())
-            await this.pluginsServer.redis.expire(hooksCacheKey, 10)
-            clearTimeout(timeout4)
+        } finally {
+            clearTimeout(timeout)
         }
-        clearTimeout(timeout)
-        return shouldSendHooksTask
+        return false
     }
 
     private async createEvent(


### PR DESCRIPTION
## Changes

- The `redis.get` call caused the app to freeze, so removing it for now.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
