### PR TITLE
Perform autobump as posthog-bot

### DIFF
--- a/.github/workflows/label-version-bump.yaml
+++ b/.github/workflows/label-version-bump.yaml
@@ -20,6 +20,7 @@ jobs:
               uses: actions/checkout@v2
               with:
                   ref: master
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Detect version bump type
               id: bump-type
@@ -60,6 +61,4 @@ jobs:
               uses: EndBug/add-and-commit@v7
               with:
                   branch: master
-                  author_name: PostHog Bot
-                  author_email: hey@posthog.com
                   message: 'Bump version to ${{ steps.new-version.outputs.new-version }}'

--- a/.github/workflows/label-version-bump.yaml
+++ b/.github/workflows/label-version-bump.yaml
@@ -59,6 +59,7 @@ jobs:
               if: steps.bump-type.outputs.bump-type != 'null'
               uses: EndBug/add-and-commit@v7
               with:
+                  branch: master
                   author_name: PostHog Bot
                   author_email: hey@posthog.com
                   message: 'Bump version to ${{ steps.new-version.outputs.new-version }}'

--- a/.github/workflows/label-version-bump.yaml
+++ b/.github/workflows/label-version-bump.yaml
@@ -18,6 +18,8 @@ jobs:
         steps:
             - name: Check out repository
               uses: actions/checkout@v2
+              with:
+                  ref: master
 
             - name: Detect version bump type
               id: bump-type


### PR DESCRIPTION
Gets around branch being protected and workflows not being triggered on events authored by the GH Actions faux user.