### PR TITLE
Don't "ALTER TABLE person UPDATE"

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -111,7 +111,15 @@ export class DB {
     public async fetchPersons(database: Database.ClickHouse): Promise<ClickHousePerson[]>
     public async fetchPersons(database: Database = Database.Postgres): Promise<Person[] | ClickHousePerson[]> {
         if (database === Database.ClickHouse) {
-            return (await this.clickhouseQuery('SELECT * FROM person')).data as ClickHousePerson[]
+            const query = `
+                SELECT * FROM person JOIN (
+                    SELECT id, max(_timestamp) as _timestamp FROM person GROUP BY team_id, id
+                ) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp
+            `
+            return (await this.clickhouseQuery(query)).data.map((row) => {
+                const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row
+                return rest
+            }) as ClickHousePerson[]
         } else if (database === Database.Postgres) {
             return ((await this.postgresQuery('SELECT * FROM posthog_person')).rows as RawPerson[]).map(
                 (rawPerson: RawPerson) =>
@@ -215,6 +223,26 @@ export class DB {
             )} WHERE id = $${Object.values(update).length + 1}`,
             values
         )
+
+        if (this.kafkaProducer) {
+            await this.sendKafkaMessage({
+                topic: KAFKA_PERSON,
+                messages: [
+                    {
+                        value: Buffer.from(
+                            JSON.stringify({
+                                created_at: castTimestampOrNow(updatedPerson.created_at, TimestampFormat.ClickHouse),
+                                properties: JSON.stringify(updatedPerson.properties),
+                                team_id: updatedPerson.team_id,
+                                is_identified: updatedPerson.is_identified,
+                                id: updatedPerson.uuid,
+                            })
+                        ),
+                    },
+                ],
+            })
+        }
+
         return updatedPerson
     }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -215,24 +215,6 @@ export class DB {
             )} WHERE id = $${Object.values(update).length + 1}`,
             values
         )
-        if (this.clickhouse) {
-            const { is_user_id, id, uuid, ...validUpdates } = update
-            const updateString = Object.entries(validUpdates)
-                .map(([key, value]) => {
-                    let clickhouseValue: string
-                    if (typeof value === 'string') {
-                        clickhouseValue = value
-                    } else if (typeof value === 'boolean') {
-                        clickhouseValue = value ? '1' : '0'
-                    } else if (DateTime.isDateTime(value)) {
-                        clickhouseValue = castTimestampOrNow(value, TimestampFormat.ClickHouseSecondPrecision)
-                    } else {
-                        clickhouseValue = JSON.stringify(value)
-                    }
-                    return `${sanitizeSqlIdentifier(key)} = '${escapeClickHouseString(clickhouseValue)}'`
-                })
-                .join(', ')
-        }
         return updatedPerson
     }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -231,7 +231,10 @@ export class DB {
                     {
                         value: Buffer.from(
                             JSON.stringify({
-                                created_at: castTimestampOrNow(updatedPerson.created_at, TimestampFormat.ClickHouse),
+                                created_at: castTimestampOrNow(
+                                    updatedPerson.created_at,
+                                    TimestampFormat.ClickHouseSecondPrecision
+                                ),
                                 properties: JSON.stringify(updatedPerson.properties),
                                 team_id: updatedPerson.team_id,
                                 is_identified: updatedPerson.is_identified,

--- a/src/db.ts
+++ b/src/db.ts
@@ -232,11 +232,6 @@ export class DB {
                     return `${sanitizeSqlIdentifier(key)} = '${escapeClickHouseString(clickhouseValue)}'`
                 })
                 .join(', ')
-            if (updateString.length > 0) {
-                await this.clickhouseQuery(
-                    `ALTER TABLE person UPDATE ${updateString} WHERE id = '${escapeClickHouseString(person.uuid)}'`
-                )
-            }
         }
         return updatedPerson
     }

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -112,6 +112,7 @@ export async function createUserTeamAndOrganization(
         plugins_opt_in: true,
         opt_out_capture: false,
         is_demo: false,
+        api_token: `THIS IS NOT A TOKEN FOR TEAM ${teamId}`,
     })
 }
 


### PR DESCRIPTION
## Changes

`ALTER TABLE person UPDATE` is ran on every person-updating event and, due to the way ClickHouse works, that causes a drastic increase of load in terms of `person` parts. This contributed to the ClickHouse crash on 100% plugin server ingestion. Before rolling out plugin server ingestion, we need to solve person updates differently.
This PR simply eliminates the update query – not great for data integrity… but also the way Python ingestion is anyway…
Long term, we need a better solution.