### PR TITLE
Send all Redis commands via DB

### DIFF
--- a/src/celery/base.ts
+++ b/src/celery/base.ts
@@ -2,15 +2,14 @@
  * writes here Base Parent class of Celery client and worker
  * @author SunMyeong Lee <actumn814@gmail.com>
  */
-import * as Redis from 'ioredis'
-
-import RedisBroker from './broker'
+import { DB } from '../db'
+import { Broker } from './broker'
 import { CeleryConf, defaultConf } from './conf'
 
 export default class Base {
-    broker: RedisBroker
+    broker: Broker
     conf: CeleryConf
-    redis: Redis.Redis
+    db: DB
 
     /**
      * Parent Class of Client and Worker
@@ -18,11 +17,11 @@ export default class Base {
      *
      * @constructor Base
      */
-    constructor(redis: Redis.Redis, queue = 'celery') {
-        this.redis = redis
+    constructor(db: DB, queue = 'celery') {
+        this.db = db
         this.conf = defaultConf()
         this.conf.CELERY_QUEUE = queue
-        this.broker = new RedisBroker(this.redis)
+        this.broker = new Broker(db)
     }
 
     /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -163,6 +163,25 @@ export class DB {
         }
     }
 
+    public async redisLPush(key: string, value: unknown, stringify = true): Promise<number> {
+        const timeout = timeoutGuard(`LPushing redis key delayed. Waiting over 30 sec to lpush key: ${key}`)
+        try {
+            const serializedValue = stringify ? JSON.stringify(value) : (value as string)
+            return await this.redis.lpush(key, serializedValue)
+        } finally {
+            clearTimeout(timeout)
+        }
+    }
+
+    public async redisBRPop(key1: string, key2: string): Promise<[string, string]> {
+        const timeout = timeoutGuard(`BRPoping redis key delayed. Waiting over 30 sec to brpop keys: ${key1}, ${key2}`)
+        try {
+            return await this.redis.brpop(key1, key2)
+        } finally {
+            clearTimeout(timeout)
+        }
+    }
+
     // Person
 
     public async fetchPersons(database?: Database.Postgres): Promise<Person[]>

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -59,6 +59,9 @@ export class EventsProcessor {
             throw new Error(`Not a valid UUID: "${eventUuid}"`)
         }
         const singleSaveTimer = new Date()
+        const timeout = timeoutGuard(
+            `Still inside "EventsProcessor.processEvent". Timeout warning after 30 sec! ${JSON.stringify(data)}`
+        )
 
         const properties: Properties = data.properties ?? {}
         if (data['$set']) {
@@ -110,6 +113,7 @@ export class EventsProcessor {
             this.pluginsServer.statsd?.timing('kafka_queue.single_save.standard', singleSaveTimer)
             clearTimeout(timeout3)
         }
+        clearTimeout(timeout)
 
         return result
     }

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -38,7 +38,7 @@ export class EventsProcessor {
         this.db = pluginsServer.db
         this.clickhouse = pluginsServer.clickhouse!
         this.kafkaProducer = pluginsServer.kafkaProducer!
-        this.celery = new Client(pluginsServer.redis, pluginsServer.CELERY_DEFAULT_QUEUE)
+        this.celery = new Client(pluginsServer.db, pluginsServer.CELERY_DEFAULT_QUEUE)
         this.posthog = nodePostHog('sTMFPsFhdP1Ssg', { fetch })
         if (process.env.NODE_ENV === 'test') {
             this.posthog.optOut()

--- a/src/server.ts
+++ b/src/server.ts
@@ -273,9 +273,8 @@ export async function startPluginsServer(
 
         // every 5 seconds set Redis keys @posthog-plugin-server/ping and @posthog-plugin-server/version
         pingJob = schedule.scheduleJob('*/5 * * * * *', () => {
-            server!.redis!.set('@posthog-plugin-server/ping', new Date().toISOString())
-            server!.redis!.expire('@posthog-plugin-server/ping', 60)
-            server!.redis!.set('@posthog-plugin-server/version', version)
+            server!.db!.redisSet('@posthog-plugin-server/ping', new Date().toISOString(), 60, false)
+            server!.db!.redisSet('@posthog-plugin-server/version', version)
         })
 
         // every 10 seconds sends stuff to StatsD

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,7 +129,7 @@ export async function createServer(
               }
             : undefined,
     })
-    const db = new DB(postgres, kafkaProducer, clickhouse)
+    const db = new DB(postgres, redis, kafkaProducer, clickhouse)
 
     let statsd: StatsD | undefined
     if (serverConfig.STATSD_HOST) {

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -51,7 +51,7 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
         }
     } else {
         // Sending event to our Redis>Postgres pipeline
-        const client = new Client(server.redis, server.PLUGINS_CELERY_QUEUE)
+        const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
         sendEvent = async (data) => {
             client.sendTask(
                 'posthog.tasks.process_event.process_event_with_plugins',

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -59,11 +59,7 @@ export async function createPluginConfigVM(
 
     vm.freeze(
         {
-            cache: createCache(
-                server,
-                pluginConfig.plugin?.name || pluginConfig.plugin_id.toString(),
-                pluginConfig.team_id
-            ),
+            cache: createCache(server, pluginConfig.plugin_id, pluginConfig.team_id),
             config: pluginConfig.config,
             attachments: pluginConfig.attachments,
             storage: createStorage(server, pluginConfig),

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -57,8 +57,8 @@ async function startQueueRedis(
     piscina: Piscina | undefined,
     workerMethods: WorkerMethods
 ): Promise<Queue> {
-    const celeryQueue = new Worker(server.redis, server.PLUGINS_CELERY_QUEUE)
-    const client = new Client(server.redis, server.CELERY_DEFAULT_QUEUE)
+    const celeryQueue = new Worker(server.db, server.PLUGINS_CELERY_QUEUE)
+    const client = new Client(server.db, server.CELERY_DEFAULT_QUEUE)
 
     celeryQueue.register(
         'posthog.tasks.process_event.process_event_with_plugins',

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -46,7 +46,7 @@ test('worker and task passing via redis', async () => {
 
     // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
     // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
-    const client = new Client(server.redis, server.PLUGINS_CELERY_QUEUE)
+    const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
 
     // It's there
@@ -124,7 +124,7 @@ test('process multiple tasks', async () => {
 
     // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
     // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
-    const client = new Client(server.redis, server.PLUGINS_CELERY_QUEUE)
+    const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
@@ -188,7 +188,7 @@ test('pause and resume queue', async () => {
 
     // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
     // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
-    const client = new Client(server.redis, server.PLUGINS_CELERY_QUEUE)
+    const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
     client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -136,7 +136,7 @@ test('pause the queue if too many tasks', async () => {
 
     expect(pluginsServer.piscina.queueSize).toBe(0)
 
-    const client = new Client(pluginsServer.server.redis, pluginsServer.server.PLUGINS_CELERY_QUEUE)
+    const client = new Client(pluginsServer.server.db, pluginsServer.server.PLUGINS_CELERY_QUEUE)
     for (let i = 0; i < 2; i++) {
         client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
     }


### PR DESCRIPTION
## Changes

- Everything except `redlock` should now use redis via the `db.redis*` methods

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
