### PR TITLE
ESLint Promise Rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,10 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
+    parserOptions: {
+        sourceType: 'module',
+        tsconfigRootDir: __dirname,
+        project: ['./tsconfig.eslint.json'],
+    },
     plugins: ['@typescript-eslint', 'simple-import-sort'],
     extends: ['plugin:@typescript-eslint/recommended', 'prettier', 'prettier/@typescript-eslint', 'prettier/react'],
     ignorePatterns: ['bin', 'dist', 'node_modules'],
@@ -11,6 +16,8 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
+        'require-await': 'off',
+        '@typescript-eslint/require-await': 'error',
         curly: 'error',
     },
     overrides: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,9 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         'require-await': 'off',
         '@typescript-eslint/require-await': 'error',
+        '@typescript-eslint/await-thenable': 'error',
+        '@typescript-eslint/no-floating-promises': 'error',
+        '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
         curly: 'error',
     },
     overrides: [

--- a/benchmarks/clickhouse/e2e.kafka.benchmark.ts
+++ b/benchmarks/clickhouse/e2e.kafka.benchmark.ts
@@ -67,14 +67,14 @@ describe('e2e kafka & clickhouse benchmark', () => {
             const uuid = new UUIDT().toString()
             posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        await queue.pause()
+        queue.pause()
         for (let i = 0; i < count; i++) {
             createEvent()
         }
 
         // hope that 5sec is enough to load kafka with all the events (posthog.capture can't be awaited)
         await delay(5000)
-        await queue.resume()
+        queue.resume()
 
         console.log('Starting timer')
         const startTime = performance.now()

--- a/benchmarks/clickhouse/e2e.kafka.benchmark.ts
+++ b/benchmarks/clickhouse/e2e.kafka.benchmark.ts
@@ -67,7 +67,7 @@ describe('e2e kafka & clickhouse benchmark', () => {
             const uuid = new UUIDT().toString()
             posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        queue.pause()
+        await queue.pause()
         for (let i = 0; i < count; i++) {
             createEvent()
         }

--- a/benchmarks/clickhouse/e2e.timeout.benchmark.ts
+++ b/benchmarks/clickhouse/e2e.timeout.benchmark.ts
@@ -65,14 +65,14 @@ describe('e2e kafka processing timeout benchmark', () => {
             const uuid = new UUIDT().toString()
             posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        await queue.pause()
+        queue.pause()
         for (let i = 0; i < count; i++) {
             createEvent()
         }
 
         // hope that 5sec is enough to load kafka with all the events (posthog.capture can't be awaited)
         await delay(5000)
-        await queue.resume()
+        queue.resume()
 
         console.log('Starting timer')
         const startTime = performance.now()

--- a/benchmarks/clickhouse/e2e.timeout.benchmark.ts
+++ b/benchmarks/clickhouse/e2e.timeout.benchmark.ts
@@ -65,7 +65,7 @@ describe('e2e kafka processing timeout benchmark', () => {
             const uuid = new UUIDT().toString()
             posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        queue.pause()
+        await queue.pause()
         for (let i = 0; i < count; i++) {
             createEvent()
         }

--- a/benchmarks/postgres/e2e.celery.benchmark.ts
+++ b/benchmarks/postgres/e2e.celery.benchmark.ts
@@ -61,14 +61,14 @@ describe('e2e celery & postgres benchmark', () => {
             const uuid = new UUIDT().toString()
             posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        await queue.pause()
+        queue.pause()
         expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toEqual(0)
         for (let i = 0; i < count; i++) {
-            await createEvent()
+            createEvent()
         }
         await delay(1000)
         expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toEqual(count)
-        await queue.resume()
+        queue.resume()
 
         console.log('Starting timer')
         const startTime = performance.now()

--- a/benchmarks/postgres/e2e.celery.benchmark.ts
+++ b/benchmarks/postgres/e2e.celery.benchmark.ts
@@ -61,7 +61,7 @@ describe('e2e celery & postgres benchmark', () => {
             const uuid = new UUIDT().toString()
             posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        queue.pause()
+        await queue.pause()
         expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toEqual(0)
         for (let i = 0; i < count; i++) {
             createEvent()

--- a/src/celery/client.ts
+++ b/src/celery/client.ts
@@ -108,10 +108,7 @@ export default class Client extends Base {
     public sendTask(taskName: string, args?: Array<any>, kwargs?: Record<string, any>, taskId?: string): void {
         taskId = taskId || v4()
         const message = this.createTaskMessage(taskId, taskName, args, kwargs)
-        this.sendTaskMessage(taskName, message)
-            .then(() => true)
-            .catch((error) => {
-                throw error
-            })
+        // run in the background
+        void this.sendTaskMessage(taskName, message)
     }
 }

--- a/src/celery/client.ts
+++ b/src/celery/client.ts
@@ -22,14 +22,14 @@ export default class Client extends Base {
         return this.taskProtocols[this.conf.TASK_PROTOCOL]
     }
 
-    public sendTaskMessage(taskName: string, message: TaskMessage): void {
+    public async sendTaskMessage(taskName: string, message: TaskMessage): Promise<void> {
         const { headers, properties, body /*, sentEvent */ } = message
 
         const exchange = ''
         // exchangeType = 'direct';
         // const serializer = 'json';
 
-        this.broker.publish(body, exchange, this.conf.CELERY_QUEUE, headers, properties)
+        await this.broker.publish(body, exchange, this.conf.CELERY_QUEUE, headers, properties)
     }
 
     public asTaskV2(taskId: string, taskName: string, args?: Array<any>, kwargs?: Record<string, any>): TaskMessage {
@@ -109,5 +109,9 @@ export default class Client extends Base {
         taskId = taskId || v4()
         const message = this.createTaskMessage(taskId, taskName, args, kwargs)
         this.sendTaskMessage(taskName, message)
+            .then(() => true)
+            .catch((error) => {
+                throw error
+            })
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,4 +45,4 @@ for (const [key, value] of Object.entries(otherArgs)) {
 }
 
 initApp(config)
-startPluginsServer(config, makePiscina)
+startPluginsServer(config, makePiscina).finally(() => true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,4 +45,4 @@ for (const [key, value] of Object.entries(otherArgs)) {
 }
 
 initApp(config)
-startPluginsServer(config, makePiscina).finally(() => true)
+void startPluginsServer(config, makePiscina) // void the returned promise

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -167,22 +167,21 @@ export class KafkaQueue implements Queue {
         return await startPromise
     }
 
-    pause(): void {
-        if (!this.wasConsumerRan || this.isPaused()) {
-            return
+    async pause(): Promise<void> {
+        if (this.wasConsumerRan && !this.isPaused()) {
+            status.info('⏳', 'Pausing Kafka consumer...')
+            this.consumer.pause([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
+            status.info('⏸', 'Kafka consumer paused!')
         }
-        status.info('⏳', 'Pausing Kafka consumer...')
-        this.consumer.pause([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
-        status.info('⏸', 'Kafka consumer paused!')
+        return Promise.resolve()
     }
 
     resume(): void {
-        if (!this.wasConsumerRan || !this.isPaused()) {
-            return
+        if (this.wasConsumerRan && this.isPaused()) {
+            status.info('⏳', 'Resuming Kafka consumer...')
+            this.consumer.resume([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
+            status.info('▶️', 'Kafka consumer resumed!')
         }
-        status.info('⏳', 'Resuming Kafka consumer...')
-        this.consumer.resume([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
-        status.info('▶️', 'Kafka consumer resumed!')
     }
 
     isPaused(): boolean {

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
-import { Consumer, EachBatchPayload, Kafka, Message } from 'kafkajs'
-import { PluginsServer, Queue, RawEventMessage } from 'types'
+import { Consumer, EachBatchPayload, Kafka } from 'kafkajs'
+import { PluginsServer, Queue } from 'types'
 
 import { status } from '../status'
 import { groupIntoBatches, killGracefully } from '../utils'
@@ -167,21 +167,21 @@ export class KafkaQueue implements Queue {
         return await startPromise
     }
 
-    async pause(): Promise<void> {
+    pause(): void {
         if (!this.wasConsumerRan || this.isPaused()) {
             return
         }
         status.info('⏳', 'Pausing Kafka consumer...')
-        await this.consumer.pause([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
+        this.consumer.pause([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
         status.info('⏸', 'Kafka consumer paused!')
     }
 
-    async resume(): Promise<void> {
+    resume(): void {
         if (!this.wasConsumerRan || !this.isPaused()) {
             return
         }
         status.info('⏳', 'Resuming Kafka consumer...')
-        await this.consumer.resume([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
+        this.consumer.resume([{ topic: this.pluginsServer.KAFKA_CONSUMPTION_TOPIC! }])
         status.info('▶️', 'Kafka consumer resumed!')
     }
 

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -388,7 +388,7 @@ export class EventsProcessor {
                 'SELECT distinct_id FROM posthog_user JOIN posthog_organizationmembership ON posthog_user.id = posthog_organizationmembership.user_id WHERE organization_id = $1',
                 [team.organization_id]
             )
-            const distinctIds: { distinct_id: string }[] = (await organizationMembers).rows
+            const distinctIds: { distinct_id: string }[] = organizationMembers.rows
             for (const { distinct_id } of distinctIds) {
                 this.posthog.identify(distinct_id)
                 this.posthog.capture('first team event ingested', { team: team.uuid })

--- a/src/server.ts
+++ b/src/server.ts
@@ -216,7 +216,7 @@ export async function startPluginsServer(
         }
         if (shutdownStatus >= 3) {
             status.info('❗️', 'Shutting down forcibly!')
-            piscina?.destroy().finally(() => true)
+            void piscina?.destroy()
             process.exit()
         }
         status.info('💤', ' Shutting down gracefully...')
@@ -290,7 +290,7 @@ export async function startPluginsServer(
     } catch (error) {
         Sentry.captureException(error)
         status.error('💥', 'Launchpad failure!', error)
-        Sentry.flush().finally(() => true) // flush in the background
+        void Sentry.flush() // flush in the background
         await closeJobs()
         process.exit(1)
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -216,7 +216,7 @@ export async function startPluginsServer(
         }
         if (shutdownStatus >= 3) {
             status.info('❗️', 'Shutting down forcibly!')
-            piscina?.destroy()
+            piscina?.destroy().finally(() => true)
             process.exit()
         }
         status.info('💤', ' Shutting down gracefully...')
@@ -256,7 +256,7 @@ export async function startPluginsServer(
         })
 
         pubSub = new Redis(server.REDIS_URL)
-        pubSub.subscribe(server.PLUGINS_RELOAD_PUBSUB_CHANNEL)
+        await pubSub.subscribe(server.PLUGINS_RELOAD_PUBSUB_CHANNEL)
         pubSub.on('message', async (channel: string, message) => {
             if (channel === server!.PLUGINS_RELOAD_PUBSUB_CHANNEL) {
                 status.info('⚡', 'Reloading plugins!')
@@ -272,9 +272,9 @@ export async function startPluginsServer(
         })
 
         // every 5 seconds set Redis keys @posthog-plugin-server/ping and @posthog-plugin-server/version
-        pingJob = schedule.scheduleJob('*/5 * * * * *', () => {
-            server!.db!.redisSet('@posthog-plugin-server/ping', new Date().toISOString(), 60, false)
-            server!.db!.redisSet('@posthog-plugin-server/version', version)
+        pingJob = schedule.scheduleJob('*/5 * * * * *', async () => {
+            await server!.db!.redisSet('@posthog-plugin-server/ping', new Date().toISOString(), 60, false)
+            await server!.db!.redisSet('@posthog-plugin-server/version', version)
         })
 
         // every 10 seconds sends stuff to StatsD
@@ -290,7 +290,7 @@ export async function startPluginsServer(
     } catch (error) {
         Sentry.captureException(error)
         status.error('💥', 'Launchpad failure!', error)
-        Sentry.flush().then(() => true) // flush in the background
+        Sentry.flush().finally(() => true) // flush in the background
         await closeJobs()
         process.exit(1)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export interface PluginsServer extends PluginsServerConfig {
 }
 
 export interface Pausable {
-    pause: () => void
+    pause: () => Promise<void>
     resume: () => void
     isPaused: () => boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,18 +73,18 @@ export interface PluginsServer extends PluginsServerConfig {
 }
 
 export interface Pausable {
-    pause: () => Promise<void>
+    pause: () => void
     resume: () => void
     isPaused: () => boolean
 }
 
 export interface Queue extends Pausable {
-    start: () => void
-    stop: () => void
+    start: () => Promise<void>
+    stop: () => Promise<void>
 }
 
 export interface Queue {
-    stop: () => void
+    stop: () => Promise<void>
 }
 
 export type PluginId = number

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -22,7 +22,7 @@ export interface DummyPostHog {
 export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig): DummyPostHog {
     const distinctId = pluginConfig.plugin?.name || `plugin-id-${pluginConfig.plugin_id}`
 
-    let sendEvent: (data: InternalData) => Promise<void>
+    let sendEvent: (data: InternalData) => Promise<void> | void
 
     if (server.KAFKA_ENABLED) {
         // Sending event to our Kafka>ClickHouse pipeline
@@ -52,7 +52,7 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
     } else {
         // Sending event to our Redis>Postgres pipeline
         const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
-        sendEvent = async (data) => {
+        sendEvent = (data) => {
             client.sendTask(
                 'posthog.tasks.process_event.process_event_with_plugins',
                 [data.distinct_id, null, null, data, pluginConfig.team_id, data.timestamp, data.timestamp],

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -30,28 +30,25 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
             if (!server.kafkaProducer) {
                 throw new Error('kafkaProducer not configured!')
             }
-            server.kafkaProducer
-                .send({
-                    topic: server.KAFKA_CONSUMPTION_TOPIC!,
-                    messages: [
-                        {
-                            key: data.uuid,
-                            value: JSON.stringify({
-                                distinct_id: data.distinct_id,
-                                ip: '',
-                                site_url: '',
-                                data: JSON.stringify(data),
-                                team_id: pluginConfig.team_id,
-                                now: data.timestamp,
-                                sent_at: data.timestamp,
-                                uuid: data.uuid,
-                            } as RawEventMessage),
-                        },
-                    ],
-                })
-                .finally(() => {
-                    // ignore the promise, run in the background just like with celery
-                })
+            // ignore the promise, run in the background just like with celery
+            void server.kafkaProducer.send({
+                topic: server.KAFKA_CONSUMPTION_TOPIC!,
+                messages: [
+                    {
+                        key: data.uuid,
+                        value: JSON.stringify({
+                            distinct_id: data.distinct_id,
+                            ip: '',
+                            site_url: '',
+                            data: JSON.stringify(data),
+                            team_id: pluginConfig.team_id,
+                            now: data.timestamp,
+                            sent_at: data.timestamp,
+                            uuid: data.uuid,
+                        } as RawEventMessage),
+                    },
+                ],
+            })
         }
     } else {
         // Sending event to our Redis>Postgres pipeline

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,6 +17,7 @@ export async function startFastifyInstance(pluginsServer: PluginsServer): Promis
     status.info('👾', 'Starting web server…')
     const fastifyInstance = buildFastifyInstance()
     try {
+        // eslint-disable-next-line
         const address = await fastifyInstance.listen(pluginsServer.WEB_PORT, pluginsServer.WEB_HOSTNAME)
         status.info('✅', `Web server listening on ${address}!`)
     } catch (error) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,8 +17,7 @@ export async function startFastifyInstance(pluginsServer: PluginsServer): Promis
     status.info('👾', 'Starting web server…')
     const fastifyInstance = buildFastifyInstance()
     try {
-        // eslint-disable-next-line
-        const address = await fastifyInstance.listen(pluginsServer.WEB_PORT, pluginsServer.WEB_HOSTNAME)
+        const address = await fastifyInstance.listen({ port: pluginsServer.WEB_PORT, host: pluginsServer.WEB_HOSTNAME })
         status.info('✅', `Web server listening on ${address}!`)
     } catch (error) {
         status.error('🛑', 'Web server could not start:\n', error)

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -17,7 +17,7 @@ export type WorkerMethods = {
 
 function pauseQueueIfWorkerFull(queue: Queue | undefined, server: PluginsServer, piscina?: Piscina) {
     if (queue && (piscina?.queueSize || 0) > (server.WORKER_CONCURRENCY || 4) * (server.WORKER_CONCURRENCY || 4)) {
-        queue.pause()
+        void queue.pause()
     }
 }
 

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -26,7 +26,6 @@ export async function startQueue(
     piscina?: Piscina,
     workerMethods: Partial<WorkerMethods> = {}
 ): Promise<Queue> {
-    const relevantStartQueue = server.KAFKA_ENABLED ? startQueueKafka : startQueueRedis
     const mergedWorkerMethods = {
         processEvent: (event: PluginEvent) => {
             return piscina!.runTask({ task: 'processEvent', args: { event } })
@@ -44,7 +43,7 @@ export async function startQueue(
         if (server.KAFKA_ENABLED) {
             return await startQueueKafka(server, mergedWorkerMethods)
         } else {
-            return await startQueueRedis(server, piscina, mergedWorkerMethods)
+            return startQueueRedis(server, piscina, mergedWorkerMethods)
         }
     } catch (error) {
         status.error('💥', 'Failed to start event queue:\n', error)
@@ -52,11 +51,7 @@ export async function startQueue(
     }
 }
 
-async function startQueueRedis(
-    server: PluginsServer,
-    piscina: Piscina | undefined,
-    workerMethods: WorkerMethods
-): Promise<Queue> {
+function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, workerMethods: WorkerMethods): Queue {
     const celeryQueue = new Worker(server.db, server.PLUGINS_CELERY_QUEUE)
     const client = new Client(server.db, server.CELERY_DEFAULT_QUEUE)
 

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -43,7 +43,7 @@ export async function startQueue(
         if (server.KAFKA_ENABLED) {
             return await startQueueKafka(server, mergedWorkerMethods)
         } else {
-            return startQueueRedis(server, piscina, mergedWorkerMethods)
+            return await startQueueRedis(server, piscina, mergedWorkerMethods)
         }
     } catch (error) {
         status.error('💥', 'Failed to start event queue:\n', error)
@@ -51,7 +51,11 @@ export async function startQueue(
     }
 }
 
-function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, workerMethods: WorkerMethods): Queue {
+async function startQueueRedis(
+    server: PluginsServer,
+    piscina: Piscina | undefined,
+    workerMethods: WorkerMethods
+): Promise<Queue> {
     const celeryQueue = new Worker(server.db, server.PLUGINS_CELERY_QUEUE)
     const client = new Client(server.db, server.CELERY_DEFAULT_QUEUE)
 
@@ -93,7 +97,7 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
         }
     )
 
-    celeryQueue.start()
+    await celeryQueue.start()
 
     return celeryQueue
 }

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -94,7 +94,7 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
     )
 
     // run in the background
-    celeryQueue.start().finally(() => true)
+    void celeryQueue.start()
 
     return celeryQueue
 }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -16,11 +16,8 @@ export async function createWorker(config: PluginsServerConfig, threadId: number
     const [server, closeServer] = await createServer(config, threadId)
     await setupPlugins(server)
 
-    const closeJobs = async () => {
-        await closeServer()
-    }
     for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
-        process.on(signal, closeJobs)
+        process.on(signal, closeServer)
     }
 
     return async ({ task, args }) => {

--- a/tests/clickhouse/ingestion-utils.test.ts
+++ b/tests/clickhouse/ingestion-utils.test.ts
@@ -1,6 +1,6 @@
 import { chainToElements, elementsToString } from '../../src/ingestion/utils'
 
-test('elementsToString and chainToElements', async () => {
+test('elementsToString and chainToElements', () => {
     const elementsString = elementsToString([
         {
             tag_name: 'a',

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { getDefaultConfig, overrideWithEnv } from '../src/config'
 
-test('overrideWithEnv 1', async () => {
+test('overrideWithEnv 1', () => {
     const defaultConfig = getDefaultConfig()
     const env = {
         DISABLE_WEB: 'false',
@@ -16,7 +16,7 @@ test('overrideWithEnv 1', async () => {
     expect(config.BASE_DIR).toEqual(defaultConfig.BASE_DIR)
 })
 
-test('overrideWithEnv 2', async () => {
+test('overrideWithEnv 2', () => {
     const defaultConfig = getDefaultConfig()
     const env = {
         DISABLE_WEB: '1',

--- a/tests/helpers/kafka.ts
+++ b/tests/helpers/kafka.ts
@@ -55,6 +55,7 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
         console.info('running consumer')
         await consumer.run({
             eachMessage: async (payload) => {
+                await Promise.resolve()
                 console.info('message received!')
                 messages.push(payload)
             },

--- a/tests/helpers/kafka.ts
+++ b/tests/helpers/kafka.ts
@@ -36,7 +36,7 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
         KAFKA_PERSON_UNIQUE_ID,
     ])
 
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>(async (resolve, reject) => {
         console.info('setting group join and crash listeners')
         const { CONNECT, GROUP_JOIN, CRASH } = consumer.events
         consumer.on(CONNECT, () => {
@@ -47,30 +47,34 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
             resolve()
         })
         consumer.on(CRASH, ({ payload: { error } }) => reject(error))
+
+        console.info('connecting producer')
+        await producer.connect()
+
+        console.info('subscribing consumer')
+        await consumer.subscribe({ topic: KAFKA_EVENTS_PLUGIN_INGESTION })
+
+        console.info('running consumer')
+        await consumer.run({
+            eachMessage: async (payload) => {
+                await Promise.resolve()
+                console.info('message received!')
+                messages.push(payload)
+            },
+        })
+
+        console.info(`awaiting ${delayMs} ms before disconnecting`)
+        await delay(delayMs)
+
+        console.info('disconnecting producer')
+        await producer.disconnect()
+
+        console.info('stopping consumer')
+        await consumer.stop()
+
+        console.info('disconnecting consumer')
+        await consumer.disconnect()
     })
-    console.info('connecting producer')
-    await producer.connect()
-    console.info('subscribing consumer')
-
-    await consumer.subscribe({ topic: KAFKA_EVENTS_PLUGIN_INGESTION })
-    console.info('running consumer')
-    await consumer.run({
-        eachMessage: async (payload) => {
-            await Promise.resolve()
-            console.info('message received!')
-            messages.push(payload)
-        },
-    })
-
-    console.info(`awaiting ${delayMs} ms before disconnecting`)
-    await delay(delayMs)
-
-    console.info('disconnecting producer')
-    await producer.disconnect()
-    console.info('stopping consumer')
-    await consumer.stop()
-    console.info('disconnecting consumer')
-    await consumer.disconnect()
 
     return true
 }

--- a/tests/helpers/kafka.ts
+++ b/tests/helpers/kafka.ts
@@ -36,7 +36,7 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
         KAFKA_PERSON_UNIQUE_ID,
     ])
 
-    const connected = await new Promise<void>(async (resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
         console.info('setting group join and crash listeners')
         const { CONNECT, GROUP_JOIN, CRASH } = consumer.events
         consumer.on(CONNECT, () => {
@@ -47,19 +47,19 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
             resolve()
         })
         consumer.on(CRASH, ({ payload: { error } }) => reject(error))
-        console.info('connecting producer')
-        await producer.connect()
-        console.info('subscribing consumer')
+    })
+    console.info('connecting producer')
+    await producer.connect()
+    console.info('subscribing consumer')
 
-        await consumer.subscribe({ topic: KAFKA_EVENTS_PLUGIN_INGESTION })
-        console.info('running consumer')
-        await consumer.run({
-            eachMessage: async (payload) => {
-                await Promise.resolve()
-                console.info('message received!')
-                messages.push(payload)
-            },
-        })
+    await consumer.subscribe({ topic: KAFKA_EVENTS_PLUGIN_INGESTION })
+    console.info('running consumer')
+    await consumer.run({
+        eachMessage: async (payload) => {
+            await Promise.resolve()
+            console.info('message received!')
+            messages.push(payload)
+        },
     })
 
     console.info(`awaiting ${delayMs} ms before disconnecting`)

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -112,7 +112,7 @@ export async function createUserTeamAndOrganization(
         plugins_opt_in: true,
         opt_out_capture: false,
         is_demo: false,
-        api_token: 'THIS IS NOT A TOKEN',
+        api_token: `THIS IS NOT A TOKEN FOR TEAM ${teamId}`,
     })
 }
 

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -112,6 +112,7 @@ export async function createUserTeamAndOrganization(
         plugins_opt_in: true,
         opt_out_capture: false,
         is_demo: false,
+        api_token: 'THIS IS NOT A TOKEN',
     })
 }
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -18,8 +18,8 @@ let closeServer: () => Promise<void>
 beforeEach(async () => {
     ;[mockServer, closeServer] = await createServer({ LOG_LEVEL: LogLevel.Log })
 })
-afterEach(() => {
-    closeServer()
+afterEach(async () => {
+    await closeServer()
 })
 
 test('setupPlugins and runPlugins', async () => {

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -210,8 +210,7 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(0)
 
-    queue.pause()
-    await advanceOneTick()
+    await queue.pause()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(1)
@@ -241,13 +240,13 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(2)
 
-    queue.pause()
+    await queue.pause()
     await advanceOneTick()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(3)
 
-    queue.pause()
+    await queue.pause()
     await advanceOneTick()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -210,7 +210,7 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(0)
 
-    await queue.pause()
+    queue.pause()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(1)
@@ -225,7 +225,7 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(1)
 
-    await queue.resume()
+    queue.resume()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(1)
@@ -240,13 +240,13 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(2)
 
-    await queue.pause()
+    queue.pause()
     await advanceOneTick()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(3)
 
-    await queue.pause()
+    queue.pause()
     await advanceOneTick()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
@@ -257,7 +257,7 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(3)
 
-    await queue.resume()
+    queue.resume()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(3)

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -211,6 +211,7 @@ test('pause and resume queue', async () => {
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(0)
 
     queue.pause()
+    await advanceOneTick()
 
     expect(await server.redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(5)
     expect(await server.redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(1)

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -177,6 +177,7 @@ test('pause the queue if too many tasks', async () => {
             await delay(100)
         }
     }
+    await delay(100)
 
     expect(await pluginsServer.server.redis.llen(pluginsServer.server.PLUGINS_CELERY_QUEUE)).toBe(32)
     expect(await pluginsServer.server.redis.llen(pluginsServer.server.CELERY_DEFAULT_QUEUE)).toBe(10)

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -10,8 +10,8 @@ beforeEach(async () => {
     ;[server, closeServer] = await createServer()
     await resetTestDatabase(`const processEvent = event => event`)
 })
-afterEach(() => {
-    closeServer()
+afterEach(async () => {
+    await closeServer()
 })
 
 test('getPluginAttachmentRows', async () => {
@@ -28,7 +28,7 @@ test('getPluginAttachmentRows', async () => {
             team_id: 2,
         },
     ])
-    server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
+    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
     const rows2 = await getPluginAttachmentRows(server)
     expect(rows2).toEqual([])
 })
@@ -49,7 +49,7 @@ test('getPluginConfigRows', async () => {
             team_id: 2,
         },
     ])
-    server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
+    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
     const rows2 = await getPluginConfigRows(server)
     expect(rows2).toEqual([])
 })
@@ -94,7 +94,7 @@ test('getPluginRows', async () => {
             url: 'https://www.npmjs.com/package/posthog-maxmind-plugin',
         },
     ])
-    server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
+    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
     const rows2 = await getPluginRows(server)
     expect(rows2).toEqual([])
 })

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -10,8 +10,8 @@ beforeEach(async () => {
     ;[server, closeServer] = await createServer()
     await resetTestDatabase(`const processEvent = event => event`)
 })
-afterEach(() => {
-    closeServer()
+afterEach(async () => {
+    await closeServer()
 })
 
 describe('secureCode', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -272,6 +272,8 @@ describe('UUID', () => {
     describe('#valueOf', () => {
         it('returns the right big integer', () => {
             const uuid = new UUID('99aBcDeF-1234-4321-0000-dcba87654321')
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             expect(uuid.valueOf()).toStrictEqual(0x99abcdef123443210000dcba87654321n)
         })
     })

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -64,13 +64,13 @@ test('getFileFromZip & getFileFromArchive', async () => {
     await expect(getFileFromArchive(Buffer.from('haha'), 'broken.json')).rejects.toThrow()
 })
 
-test('bufferToStream', async () => {
+test('bufferToStream', () => {
     const buffer = Buffer.from(zip, 'base64')
     const stream = bufferToStream(buffer)
     expect(stream.read()).toEqual(buffer)
 })
 
-test('setLogLevel', async () => {
+test('setLogLevel', () => {
     function resetMocks() {
         console.debug = jest.fn()
         console.info = jest.fn()
@@ -158,7 +158,7 @@ test('setLogLevel', async () => {
     expect((console.error as any)._original).toBeDefined()
 })
 
-test('cloneObject', async () => {
+test('cloneObject', () => {
     const o1 = ['string', 'value']
     expect(cloneObject(o1)).toEqual(o1)
     expect(cloneObject(o1) === o1).toBe(false)

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": "./",
+        "rootDir": "./",
+        "noEmit": true
+    },
+    "include": [".", "src", "tests", ".eslintrc.js"],
+    "exclude": ["node_modules", "dist", "bin"]
+}


### PR DESCRIPTION
## Changes

- I added a few eslint rules to track down unhandled or otherwise misused promises.
- This possibly fixed a few flaky tests, as we were not really awaiting `closeServer` and a few other things in some places
- A few places got a `.finally(() => true)` to explicitly say we don't care about the returned promise

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
