### PR TITLE
Make plugin server ingestion the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | CELERY_DEFAULT_QUEUE          | Celery outgoing queue                                               | `'celery'`                            |
 | PLUGINS_CELERY_QUEUE          | Celery incoming queue                                               | `'posthog-plugins'`                   |
 | PLUGINS_RELOAD_PUBSUB_CHANNEL | Redis channel for reload events                                     | `'reload-plugins'`                    |
-| PLUGIN_SERVER_INGESTION       | Whether the plugin server should put events right into the database | `false`                               |
+| PLUGIN_SERVER_INGESTION       | Whether the plugin server should put events right into the database | `true`                                |
 | CLICKHOUSE_HOST               | ClickHouse host                                                     | `'localhost'`                         |
 | CLICKHOUSE_DATABASE           | ClickHouse database                                                 | `'default'`                           |
 | CLICKHOUSE_USER               | ClickHouse username                                                 | `'default'`                           |

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CLIENT_CERT_KEY_B64: null,
         KAFKA_TRUSTED_CERT_B64: null,
         KAFKA_CONSUMPTION_TOPIC: null,
-        PLUGIN_SERVER_INGESTION: false,
+        PLUGIN_SERVER_INGESTION: true,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',
         BASE_DIR: '.',


### PR DESCRIPTION
## Changes

Let's make PLUGIN_SERVER_INGESTION _the_ way.

The complimentary PR in main repo will need to also be adjusted for the new default.

**Warning: this has "bump major" which will result in 1.0.0 release.**

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
