### PR TITLE
Proposal: Run scheduled tasks immediately at setup

### DIFF
--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -82,6 +82,12 @@ export async function startSchedule(
 
     server.pluginSchedule = await piscina.runTask({ task: 'getPluginSchedule' })
 
+    if (!stopped) {
+        runTasksDebounced(server!, piscina!, 'runEveryMinute')
+        runTasksDebounced(server!, piscina!, 'runEveryHour')
+        runTasksDebounced(server!, piscina!, 'runEveryDay')
+    }
+
     const runEveryMinuteJob = schedule.scheduleJob('* * * * *', () => {
         !stopped && weHaveTheLock && runTasksDebounced(server!, piscina!, 'runEveryMinute')
     })


### PR DESCRIPTION
## PRs over issues

The only reason this is a PR is for context, not because this is a proper solution that should get merged. I haven't looked too deeply at how anything works.

## Proposal
The proposal here is essentially to run scheduled tasks right after setup. 

## Motivation
Here https://github.com/PostHog/github-release-tracking-plugin/issues/2 @mariusandra suggests that in order to give my users immediate feedback of my `runEveryDay` plugin working, I should use the cache to determine when was the last time the values were fetched and run the task more often.

This is certainly fine and quite easy to do, but it's not something I want to do as a plugin developer (I'm thinking from a community perspective here). 

For example, if I have a task called `runEveryDay`, why should I rather `runEveryHour` and use the cache to check if it's been a day? 

Plus, the same issue applies to `runEveryHour`. The only way to give immediate feedback to a user now is to use `runEveryMinute`. 

## Proposed Solution

Run the scheduled tasks once at setup. The PR is here for context but it doesn't mean that this is how things would necessarily work. Essentially I want immediate feedback of my plugin running and working with no extra work from my end. 

I, the plugin developer, am lazy. :open_mouth: 

## Pros

- Immediate feedback
- Faster debugging
- Simpler for plugin developers
- Suitable for most plugin types 
    - Especially those where the schedule is more of an arbitrary selection that a surgically precise decision e.g. Release Tracker: I want to check for releases frequently enough but not too frequently, so it's ok for me that it checks immediately, then the next time is let's say within 13h, and then it kicks into the 24h schedule. 
    
## Cons

- Will throw off the schedule for the first cycle
    - Can be harmful to plugins that need precision? Which types would these be?
- Potential overhead?
- ...?

## Further thoughts

Could we have this be a plugin setting? Developer decides if tasks should run at setup, default would probably be `true`.


