### PR TITLE
Remove PLUGIN_SERVER_INGESTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,38 +27,37 @@ Let's get you developing the plugin server in no time:
 
 There's a multitude of settings you can use to control the plugin server. Use them as environment variables.
 
-| Name                          | Description                                                         | Default value                         |
-| ----------------------------- | ------------------------------------------------------------------- | ------------------------------------- |
-| DATABASE_URL                  | Postgres database URL                                               | `'postgres://localhost:5432/posthog'` |
-| REDIS_URL                     | Redis store URL                                                     | `'redis://localhost'`                 |
-| BASE_DIR                      | base path for resolving local plugins                               | `'.'`                                 |
-| WORKER_CONCURRENCY            | number of concurrent worker threads                                 | `0` – all cores                       |
-| TASKS_PER_WORKER              | number of parallel tasks per worker thread                          | `10`                                  |
-| SCHEDULE_LOCK_TTL             | How many seconds to hold the lock for the schedule                  | `60`                                  |
-| CELERY_DEFAULT_QUEUE          | Celery outgoing queue                                               | `'celery'`                            |
-| PLUGINS_CELERY_QUEUE          | Celery incoming queue                                               | `'posthog-plugins'`                   |
-| PLUGINS_RELOAD_PUBSUB_CHANNEL | Redis channel for reload events                                     | `'reload-plugins'`                    |
-| PLUGIN_SERVER_INGESTION       | Whether the plugin server should put events right into the database | `false`                               |
-| CLICKHOUSE_HOST               | ClickHouse host                                                     | `'localhost'`                         |
-| CLICKHOUSE_DATABASE           | ClickHouse database                                                 | `'default'`                           |
-| CLICKHOUSE_USER               | ClickHouse username                                                 | `'default'`                           |
-| CLICKHOUSE_PASSWORD           | ClickHouse password                                                 | `null`                                |
-| CLICKHOUSE_CA                 | ClickHouse CA certs                                                 | `null`                                |
-| CLICKHOUSE_SECURE             | Secure ClickHouse connection                                        | `false`                               |
-| KAFKA_ENABLED                 | use Kafka instead of Celery to ingest events                        | `false`                               |
-| KAFKA_HOSTS                   | comma-delimited Kafka hosts                                         | `null`                                |
-| KAFKA_CONSUMPTION_TOPIC       | Kafka consumption topic override                                    | `null` (automatic)                    |
-| KAFKA_CLIENT_CERT_B64         | Kafka certificate in Base64                                         | `null`                                |
-| KAFKA_CLIENT_CERT_KEY_B64     | Kafka certificate key in Base64                                     | `null`                                |
-| KAFKA_TRUSTED_CERT_B64        | Kafka trusted CA in Base64                                          | `null`                                |
-| DISABLE_WEB                   | whether to disable web server                                       | `true`                                |
-| WEB_PORT                      | port for web server to listen on                                    | `3008`                                |
-| WEB_HOSTNAME                  | hostname for web server to listen on                                | `'0.0.0.0'`                           |
-| LOG_LEVEL                     | minimum log level                                                   | `LogLevel.Info`                       |
-| SENTRY_DSN                    | Sentry ingestion URL                                                | `null`                                |
-| STATSD_HOST                   | StatsD host - integration disabled if this is not provided          | `null`                                |
-| STATSD_PORT                   | StatsD port                                                         | `8125`                                |
-| STATSD_PREFIX                 | StatsD prefix                                                       | `'plugin-server.'`                    |
+| Name                          | Description                                                | Default value                         |
+| ----------------------------- | ---------------------------------------------------------- | ------------------------------------- |
+| DATABASE_URL                  | Postgres database URL                                      | `'postgres://localhost:5432/posthog'` |
+| REDIS_URL                     | Redis store URL                                            | `'redis://localhost'`                 |
+| BASE_DIR                      | base path for resolving local plugins                      | `'.'`                                 |
+| WORKER_CONCURRENCY            | number of concurrent worker threads                        | `0` – all cores                       |
+| TASKS_PER_WORKER              | number of parallel tasks per worker thread                 | `10`                                  |
+| SCHEDULE_LOCK_TTL             | How many seconds to hold the lock for the schedule         | `60`                                  |
+| CELERY_DEFAULT_QUEUE          | Celery outgoing queue                                      | `'celery'`                            |
+| PLUGINS_CELERY_QUEUE          | Celery incoming queue                                      | `'posthog-plugins'`                   |
+| PLUGINS_RELOAD_PUBSUB_CHANNEL | Redis channel for reload events                            | `'reload-plugins'`                    |
+| CLICKHOUSE_HOST               | ClickHouse host                                            | `'localhost'`                         |
+| CLICKHOUSE_DATABASE           | ClickHouse database                                        | `'default'`                           |
+| CLICKHOUSE_USER               | ClickHouse username                                        | `'default'`                           |
+| CLICKHOUSE_PASSWORD           | ClickHouse password                                        | `null`                                |
+| CLICKHOUSE_CA                 | ClickHouse CA certs                                        | `null`                                |
+| CLICKHOUSE_SECURE             | Secure ClickHouse connection                               | `false`                               |
+| KAFKA_ENABLED                 | use Kafka instead of Celery to ingest events               | `false`                               |
+| KAFKA_HOSTS                   | comma-delimited Kafka hosts                                | `null`                                |
+| KAFKA_CONSUMPTION_TOPIC       | Kafka consumption topic override                           | `null` (automatic)                    |
+| KAFKA_CLIENT_CERT_B64         | Kafka certificate in Base64                                | `null`                                |
+| KAFKA_CLIENT_CERT_KEY_B64     | Kafka certificate key in Base64                            | `null`                                |
+| KAFKA_TRUSTED_CERT_B64        | Kafka trusted CA in Base64                                 | `null`                                |
+| DISABLE_WEB                   | whether to disable web server                              | `true`                                |
+| WEB_PORT                      | port for web server to listen on                           | `3008`                                |
+| WEB_HOSTNAME                  | hostname for web server to listen on                       | `'0.0.0.0'`                           |
+| LOG_LEVEL                     | minimum log level                                          | `LogLevel.Info`                       |
+| SENTRY_DSN                    | Sentry ingestion URL                                       | `null`                                |
+| STATSD_HOST                   | StatsD host - integration disabled if this is not provided | `null`                                |
+| STATSD_PORT                   | StatsD port                                                | `8125`                                |
+| STATSD_PREFIX                 | StatsD prefix                                              | `'plugin-server.'`                    |
 
 ## Releasing a new version
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | CLICKHOUSE_SECURE             | Secure ClickHouse connection                               | `false`                               |
 | KAFKA_ENABLED                 | use Kafka instead of Celery to ingest events               | `false`                               |
 | KAFKA_HOSTS                   | comma-delimited Kafka hosts                                | `null`                                |
-| KAFKA_CONSUMPTION_TOPIC       | Kafka consumption topic override                           | `null` (automatic)                    |
+| KAFKA_CONSUMPTION_TOPIC       | Kafka incoming events topic                                | `'events_plugin_ingestion'`           |
 | KAFKA_CLIENT_CERT_B64         | Kafka certificate in Base64                                | `null`                                |
 | KAFKA_CLIENT_CERT_KEY_B64     | Kafka certificate key in Base64                            | `null`                                |
 | KAFKA_TRUSTED_CERT_B64        | Kafka trusted CA in Base64                                 | `null`                                |

--- a/benchmarks/clickhouse/e2e.kafka.benchmark.ts
+++ b/benchmarks/clickhouse/e2e.kafka.benchmark.ts
@@ -19,7 +19,6 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,
     KAFKA_HOSTS: process.env.KAFKA_HOSTS || 'kafka:9092',
     WORKER_CONCURRENCY: 4,
-    PLUGIN_SERVER_INGESTION: true,
     KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
     KAFKA_BATCH_PARALELL_PROCESSING: true,
     LOG_LEVEL: LogLevel.Log,

--- a/benchmarks/clickhouse/e2e.timeout.benchmark.ts
+++ b/benchmarks/clickhouse/e2e.timeout.benchmark.ts
@@ -20,7 +20,6 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_HOSTS: process.env.KAFKA_HOSTS || 'kafka:9092',
     WORKER_CONCURRENCY: 4,
     TASK_TIMEOUT: 5,
-    PLUGIN_SERVER_INGESTION: true,
     KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
     KAFKA_BATCH_PARALELL_PROCESSING: true,
     LOG_LEVEL: LogLevel.Log,

--- a/benchmarks/postgres/e2e.celery.benchmark.ts
+++ b/benchmarks/postgres/e2e.celery.benchmark.ts
@@ -71,7 +71,7 @@ describe('e2e celery & postgres benchmark', () => {
         for (let i = 0; i < count; i++) {
             createEvent()
         }
-        await delay(1000)
+        await delay(3000)
         expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toEqual(count)
         queue.resume()
 

--- a/benchmarks/postgres/e2e.celery.benchmark.ts
+++ b/benchmarks/postgres/e2e.celery.benchmark.ts
@@ -19,7 +19,6 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
     REDIS_POOL_MAX_SIZE: 3,
     PLUGINS_CELERY_QUEUE: 'test-plugins-celery-queue',
     CELERY_DEFAULT_QUEUE: 'test-celery-default-queue',
-    PLUGIN_SERVER_INGESTION: true,
     LOG_LEVEL: LogLevel.Log,
     KAFKA_ENABLED: false,
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "start": "yarn start:dev",
         "start:dist": "node dist/index.js --base-dir ../posthog",
         "start:dev": "ts-node-dev --exit-child src/index.ts --base-dir ../posthog",
-        "start:dev:ee": "PLUGIN_SERVER_INGESTION=true KAFKA_ENABLED=true KAFKA_HOSTS=localhost:9092 yarn start:dev",
+        "start:dev:ee": "KAFKA_ENABLED=true KAFKA_HOSTS=localhost:9092 yarn start:dev",
         "build": "yarn clean && yarn compile",
         "clean": "rimraf dist/*",
         "compile:protobuf": "cd src/idl/ && rimraf protos.* && pbjs -t static-module -w commonjs -o protos.js *.proto && pbts -o protos.d.ts protos.js && eslint --fix . && prettier --write .",

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CLIENT_CERT_KEY_B64: null,
         KAFKA_TRUSTED_CERT_B64: null,
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
-        PLUGIN_SERVER_INGESTION: false,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',
         BASE_DIR: '.',
@@ -49,7 +48,6 @@ export function getDefaultConfig(): PluginsServerConfig {
 
 export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
     return {
-        PLUGIN_SERVER_INGESTION: 'Ingest events via plugin-server',
         CELERY_DEFAULT_QUEUE: 'Celery outgoing queue',
         PLUGINS_CELERY_QUEUE: 'Celery incoming queue',
         DATABASE_URL: 'Postgres database URL',

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import os from 'os'
 
+import { KAFKA_EVENTS_PLUGIN_INGESTION } from './ingestion/topics'
 import { LogLevel, PluginsServerConfig } from './types'
 
 export const defaultConfig = overrideWithEnv(getDefaultConfig())
@@ -23,7 +24,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CLIENT_CERT_B64: null,
         KAFKA_CLIENT_CERT_KEY_B64: null,
         KAFKA_TRUSTED_CERT_B64: null,
-        KAFKA_CONSUMPTION_TOPIC: null,
+        KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         PLUGIN_SERVER_INGESTION: false,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,6 @@ import { ConnectionOptions } from 'tls'
 import { defaultConfig } from './config'
 import { DB } from './db'
 import { EventsProcessor } from './ingestion/process-event'
-import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_EVENTS_WAL } from './ingestion/topics'
 import { startSchedule } from './services/schedule'
 import { status } from './status'
 import { PluginsServer, PluginsServerConfig, Queue } from './types'
@@ -78,13 +77,6 @@ export async function createServer(
             rejectUnauthorized: serverConfig.CLICKHOUSE_CA ? false : undefined,
         })
         await clickhouse.querying('SELECT 1') // test that the connection works
-
-        if (!serverConfig.KAFKA_CONSUMPTION_TOPIC) {
-            // When ingesting events, listen to the "INGESTION" topic, otherwise listen to the "WAL" and discard
-            serverConfig.KAFKA_CONSUMPTION_TOPIC = serverConfig.PLUGIN_SERVER_INGESTION
-                ? KAFKA_EVENTS_PLUGIN_INGESTION
-                : KAFKA_EVENTS_WAL
-        }
 
         kafka = new Kafka({
             clientId: `plugin-server-v${version}-${new UUIDT()}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,6 @@ export interface PluginsServerConfig extends Record<string, any> {
     WEB_PORT: number
     WEB_HOSTNAME: string
     LOG_LEVEL: LogLevel
-    PLUGIN_SERVER_INGESTION: boolean
     SENTRY_DSN: string | null
     STATSD_HOST: string | null
     STATSD_PORT: number

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -8,6 +8,7 @@ import { IngestEventResponse } from '../ingestion/ingest-event'
 import { KafkaQueue } from '../ingestion/kafka-queue'
 import { status } from '../status'
 import { PluginsServer, Queue } from '../types'
+import { UUIDT } from '../utils'
 
 export type WorkerMethods = {
     processEvent: (event: PluginEvent) => Promise<PluginEvent | null>
@@ -66,7 +67,16 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
             now: string,
             sent_at?: string
         ) => {
-            const event = { distinct_id, ip, site_url, team_id, now, sent_at, ...data } as PluginEvent
+            const event = {
+                distinct_id,
+                ip,
+                site_url,
+                team_id,
+                now,
+                sent_at,
+                uuid: new UUIDT().toString(),
+                ...data,
+            } as PluginEvent
             try {
                 pauseQueueIfWorkerFull(celeryQueue, server, piscina)
                 const processedEvent = await workerMethods.processEvent(event)

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -71,21 +71,8 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
                 pauseQueueIfWorkerFull(celeryQueue, server, piscina)
                 const processedEvent = await workerMethods.processEvent(event)
                 if (processedEvent) {
-                    if (server.PLUGIN_SERVER_INGESTION) {
-                        pauseQueueIfWorkerFull(celeryQueue, server, piscina)
-                        await workerMethods.ingestEvent(processedEvent)
-                    } else {
-                        const { distinct_id, ip, site_url, team_id, now, sent_at, ...data } = processedEvent
-                        client.sendTask('posthog.tasks.process_event.process_event', [], {
-                            distinct_id,
-                            ip,
-                            site_url,
-                            data,
-                            team_id,
-                            now,
-                            sent_at,
-                        })
-                    }
+                    pauseQueueIfWorkerFull(celeryQueue, server, piscina)
+                    await workerMethods.ingestEvent(processedEvent)
                 }
             } catch (e) {
                 Sentry.captureException(e)

--- a/src/worker/queue.ts
+++ b/src/worker/queue.ts
@@ -90,13 +90,7 @@ async function startQueueKafka(server: PluginsServer, workerMethods: WorkerMetho
     const kafkaQueue: Queue = new KafkaQueue(
         server,
         (batch: PluginEvent[]) => workerMethods.processEventBatch(batch),
-        server.PLUGIN_SERVER_INGESTION
-            ? async (event) => {
-                  await workerMethods.ingestEvent(event)
-              }
-            : async () => {
-                  // no op, but defining to avoid undefined issues
-              }
+        async (event) => void (await workerMethods.ingestEvent(event))
     )
     await kafkaQueue.start()
 

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -17,7 +17,6 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,
     KAFKA_HOSTS: process.env.KAFKA_HOSTS || 'kafka:9092',
     WORKER_CONCURRENCY: 2,
-    PLUGIN_SERVER_INGESTION: true,
     KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
     LOG_LEVEL: LogLevel.Log,
 }

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -17,7 +17,6 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,
     KAFKA_HOSTS: process.env.KAFKA_HOSTS || 'kafka:9092',
     WORKER_CONCURRENCY: 2,
-    PLUGIN_SERVER_INGESTION: true,
     LOG_LEVEL: LogLevel.Log,
 }
 

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -9,7 +9,6 @@ jest.setTimeout(180_000) // 3 minute timeout
 const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,
     KAFKA_HOSTS: process.env.KAFKA_HOSTS || 'kafka:9092',
-    PLUGIN_SERVER_INGESTION: true,
     KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
 }
 

--- a/tests/postgres/e2e.test.ts
+++ b/tests/postgres/e2e.test.ts
@@ -31,7 +31,6 @@ describe('e2e postgres ingestion', () => {
                 WORKER_CONCURRENCY: 2,
                 PLUGINS_CELERY_QUEUE: 'test-plugins-celery-queue',
                 CELERY_DEFAULT_QUEUE: 'test-celery-default-queue',
-                PLUGIN_SERVER_INGESTION: true,
                 LOG_LEVEL: LogLevel.Log,
                 KAFKA_ENABLED: false,
             },

--- a/tests/postgres/e2e.timeout.test.ts
+++ b/tests/postgres/e2e.timeout.test.ts
@@ -32,7 +32,6 @@ describe('e2e postgres ingestion timeout', () => {
                 TASK_TIMEOUT: 2,
                 PLUGINS_CELERY_QUEUE: 'test-plugins-celery-queue',
                 CELERY_DEFAULT_QUEUE: 'test-celery-default-queue',
-                PLUGIN_SERVER_INGESTION: true,
                 LOG_LEVEL: LogLevel.Log,
                 KAFKA_ENABLED: false,
             },

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -27,135 +27,6 @@ async function getServer(): Promise<[PluginsServer, () => Promise<void>]> {
     return [server, stopServer]
 }
 
-test('worker and task passing via redis', async () => {
-    const [server, stopServer] = await getServer()
-    const redis = await server.redisPool.acquire()
-    // Nothing in the redis queue
-    const queue1 = await redis.llen(server.PLUGINS_CELERY_QUEUE)
-    expect(queue1).toBe(0)
-
-    const kwargs = {
-        distinct_id: 'my-id',
-        ip: '127.0.0.1',
-        site_url: 'http://localhost',
-        data: {
-            event: '$pageview',
-            properties: {},
-        },
-        team_id: 2,
-        now: new Date().toISOString(),
-        sent_at: new Date().toISOString(),
-    }
-    const args = Object.values(kwargs)
-
-    // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
-    // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
-    const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
-    client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
-
-    await delay(1000)
-
-    const queue2 = await redis.llen(server.PLUGINS_CELERY_QUEUE)
-    expect(queue2).toBe(1)
-
-    const item2 = await redis.lpop(server.PLUGINS_CELERY_QUEUE)
-    await redis.lpush(server.PLUGINS_CELERY_QUEUE, item2)
-    const item = JSON.parse(item2)
-
-    expect(item['content-type']).toBe('application/json')
-    expect(item['headers']['lang']).toBe('js')
-    expect(item['headers']['task']).toBe('posthog.tasks.process_event.process_event_with_plugins')
-    expect(item['properties']['body_encoding']).toBe('base64')
-
-    const body = Buffer.from(item['body'], 'base64').toString()
-    const [args2, kwargs2] = JSON.parse(body)
-
-    expect(args2).toEqual(args)
-    expect(kwargs2).toEqual({})
-
-    const queue = await startQueue(server, undefined, {
-        processEvent: (event) => runPlugins(server, event),
-        processEventBatch: (events) => Promise.all(events.map((event) => runPlugins(server, event))),
-        ingestEvent: () => Promise.resolve({ success: true }),
-    })
-
-    await delay(100)
-
-    // get the new processed task from CELERY_DEFAULT_QUEUE
-    const queue3 = await redis.llen(server.CELERY_DEFAULT_QUEUE)
-    expect(queue3).toBe(1)
-    const item3 = await redis.lpop(server.CELERY_DEFAULT_QUEUE)
-    await redis.lpush(server.CELERY_DEFAULT_QUEUE, item3)
-    const processedItem = JSON.parse(item3)
-
-    expect(processedItem['content-type']).toBe('application/json')
-    expect(processedItem['headers']['lang']).toBe('js')
-    expect(processedItem['headers']['task']).toBe('posthog.tasks.process_event.process_event')
-    expect(processedItem['properties']['body_encoding']).toBe('base64')
-
-    const processedBody = Buffer.from(processedItem['body'], 'base64').toString()
-    const [args3, kwargs3] = JSON.parse(processedBody)
-
-    expect(args3).toEqual([])
-    expect(kwargs3).toEqual(kwargs)
-
-    await queue.stop()
-    await server.redisPool.release(redis)
-    await stopServer()
-})
-
-test('process multiple tasks', async () => {
-    const [server, stopServer] = await getServer()
-    const redis = await server.redisPool.acquire()
-    // Nothing in the redis queue
-    const queue1 = await redis.llen(server.PLUGINS_CELERY_QUEUE)
-    expect(queue1).toBe(0)
-
-    const kwargs = {
-        distinct_id: 'my-id',
-        ip: '127.0.0.1',
-        site_url: 'http://localhost',
-        data: {
-            event: '$pageview',
-            properties: {},
-        },
-        team_id: 2,
-        now: new Date().toISOString(),
-        sent_at: new Date().toISOString(),
-    }
-    const args = Object.values(kwargs)
-
-    // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
-    // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
-    const client = new Client(server.db, server.PLUGINS_CELERY_QUEUE)
-    client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
-    client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
-    client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
-
-    await delay(1000)
-
-    expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(3)
-    expect(await redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(0)
-
-    const queue = await startQueue(server, undefined, {
-        processEvent: async (event) => runPlugins(server, event),
-        processEventBatch: (events) => Promise.all(events.map((event) => runPlugins(server, event))),
-        ingestEvent: () => Promise.resolve({ success: true }),
-    })
-
-    await delay(1000)
-
-    expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(0)
-    expect(await redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(3)
-
-    const oneTask = await redis.lpop(server.CELERY_DEFAULT_QUEUE)
-    expect(JSON.parse(oneTask)['headers']['lang']).toBe('js')
-
-    await queue.stop()
-    await server.redisPool.release(redis)
-    await stopServer()
-})
-
 test('pause and resume queue', async () => {
     const [server, stopServer] = await getServer()
     const redis = await server.redisPool.acquire()
@@ -188,7 +59,6 @@ test('pause and resume queue', async () => {
 
     // There'll be a "tick lag" with the events moving from one queue to the next. :this_is_fine:
     expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(6)
-    expect(await redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(0)
 
     const queue = await startQueue(server, undefined, {
         processEvent: (event) => runPlugins(server, event),
@@ -202,32 +72,22 @@ test('pause and resume queue', async () => {
     await queue.pause()
 
     const pluginQueue = await redis.llen(server.PLUGINS_CELERY_QUEUE)
-    const defaultQueue = await redis.llen(server.CELERY_DEFAULT_QUEUE)
 
-    expect(pluginQueue + defaultQueue).toBe(6)
-
-    expect(pluginQueue).not.toBe(0)
-    expect(defaultQueue).not.toBe(0)
+    expect(pluginQueue).toBeGreaterThan(0)
 
     await delay(100)
 
     expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(pluginQueue)
-    expect(await redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(defaultQueue)
 
     await delay(100)
 
     expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(pluginQueue)
-    expect(await redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(defaultQueue)
 
     queue.resume()
 
     await delay(500)
 
     expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(0)
-    expect(await redis.llen(server.CELERY_DEFAULT_QUEUE)).toBe(6)
-
-    const oneTask = await redis.lpop(server.CELERY_DEFAULT_QUEUE)
-    expect(JSON.parse(oneTask)['headers']['lang']).toBe('js')
 
     await queue.stop()
     await server.redisPool.release(redis)

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -17,7 +17,6 @@ async function getServer(): Promise<[PluginsServer, () => Promise<void>]> {
         REDIS_POOL_MAX_SIZE: 3,
         PLUGINS_CELERY_QUEUE: 'ttt-test-plugins-celery-queue',
         CELERY_DEFAULT_QUEUE: 'ttt-test-celery-default-queue',
-        PLUGIN_SERVER_INGESTION: false,
         LOG_LEVEL: LogLevel.Log,
     })
 


### PR DESCRIPTION
## Changes

- Remove `PLUGIN_SERVER_INGESTION` env bool
- For OSS, if plugins are enabled, they will now also ingest and no longer send a task to celery
- For EE, only listen to the ingestion topic, no more the WAL and always ingest (all EE installations are ingesting via the plugin server, so nothing changes for anybody)
- Kind of closes #199

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
