### PR TITLE
Support distinct_id in posthog.capture

### DIFF
--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -63,10 +63,10 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
     }
 
     return {
-        capture(event, properties = {}, distinct_id = distinctId) {
+        capture(event, properties = {}) {
             const { timestamp = DateTime.utc().toISO(), ...otherProperties } = properties
             const data: InternalData = {
-                distinct_id: distinct_id,
+                distinct_id: properties['distinct_id'] || distinctId,
                 event,
                 timestamp,
                 properties: {

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -63,10 +63,10 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
     }
 
     return {
-        capture(event, properties = {}) {
+        capture(event, properties = {}, distinct_id = distinctId) {
             const { timestamp = DateTime.utc().toISO(), ...otherProperties } = properties
             const data: InternalData = {
-                distinct_id: distinctId,
+                distinct_id: distinct_id,
                 event,
                 timestamp,
                 properties: {

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -65,16 +65,16 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
 
     return {
         capture(event, properties = {}) {
-            const { timestamp = DateTime.utc().toISO(), ...otherProperties } = properties
+            const { timestamp = DateTime.utc().toISO(), distinct_id = distinctId, ...otherProperties } = properties
             const data: InternalData = {
-                distinct_id: properties['distinct_id'] || distinctId,
+                distinct_id,
                 event,
                 timestamp,
                 properties: {
                     $lib: 'posthog-plugin-server',
                     $lib_version: version,
+                    distinct_id,
                     ...otherProperties,
-                    distinct_id: properties['distinct_id'] || distinctId,
                 },
                 team_id: pluginConfig.team_id,
                 uuid: new UUIDT().toString(),

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -74,6 +74,7 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
                     $lib: 'posthog-plugin-server',
                     $lib_version: version,
                     ...otherProperties,
+                    distinct_id: properties['distinct_id'] || distinctId,
                 },
                 team_id: pluginConfig.team_id,
                 uuid: new UUIDT().toString(),

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -728,7 +728,11 @@ test('posthog in runEvery', async () => {
         expect.objectContaining({
             distinct_id: 'plugin-id-60',
             event: 'my-new-event',
-            properties: expect.objectContaining({ $lib: 'posthog-plugin-server', random: 'properties' }),
+            properties: expect.objectContaining({
+                $lib: 'posthog-plugin-server',
+                random: 'properties',
+                distinct_id: 'plugin-id-60',
+            }),
         }),
         2,
         mockSendTask.mock.calls[0][1][5],

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -797,7 +797,7 @@ test('posthog.capture accepts user-defined distinct id', async () => {
 
     expect(mockSendTask.mock.calls[0][0]).toEqual('posthog.tasks.process_event.process_event_with_plugins')
     expect(mockSendTask.mock.calls[0][1]).toEqual([
-        'plugin-id-60',
+        'custom id',
         null,
         null,
         expect.objectContaining({

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -776,3 +776,37 @@ test('posthog in runEvery with timestamp', async () => {
     ])
     expect(mockSendTask.mock.calls[0][2]).toEqual({})
 })
+
+test('posthog.capture accepts user-defined distinct id', async () => {
+    const indexJs = `
+        function runEveryMinute(meta) {
+            posthog.capture('my-new-event', { random: 'properties', distinct_id: 'custom id' })
+            return 'haha'
+        }
+    `
+    await resetTestDatabase(indexJs)
+    const vm = await createPluginConfigVM(mockServer, pluginConfig39, indexJs)
+
+    expect(Client).not.toHaveBeenCalled
+
+    const response = await vm.tasks.runEveryMinute.exec()
+    expect(response).toBe('haha')
+
+    const mockClientInstance = (Client as any).mock.instances[1]
+    const mockSendTask = mockClientInstance.sendTask
+
+    expect(mockSendTask.mock.calls[0][0]).toEqual('posthog.tasks.process_event.process_event_with_plugins')
+    expect(mockSendTask.mock.calls[0][1]).toEqual([
+        'plugin-id-60',
+        null,
+        null,
+        expect.objectContaining({
+            distinct_id: 'custom id',
+            event: 'my-new-event',
+            properties: expect.objectContaining({ $lib: 'posthog-plugin-server', random: 'properties' }),
+        }),
+        2,
+        mockSendTask.mock.calls[0][1][5],
+        mockSendTask.mock.calls[0][1][6],
+    ])
+})

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -803,7 +803,11 @@ test('posthog.capture accepts user-defined distinct id', async () => {
         expect.objectContaining({
             distinct_id: 'custom id',
             event: 'my-new-event',
-            properties: expect.objectContaining({ $lib: 'posthog-plugin-server', random: 'properties' }),
+            properties: expect.objectContaining({
+                $lib: 'posthog-plugin-server',
+                random: 'properties',
+                distinct_id: 'custom id',
+            }),
         }),
         2,
         mockSendTask.mock.calls[0][1][5],


### PR DESCRIPTION
## Changes

I'll need to write up some docs for this.

Supports passing a `distinct_id` in props to `posthog.capture` so that you can capture events for specific users on scheduled plugins.

## Checklist

-   [x] Jest tests
