### PR TITLE
Stop flipping plugin order

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -248,7 +248,7 @@ export async function runPluginsOnBatch(server: PluginsServer, batch: PluginEven
 
         let returnedEvents: PluginEvent[] = teamEvents
 
-        for (const pluginConfig of pluginsToRun.reverse()) {
+        for (const pluginConfig of pluginsToRun) {
             const timer = new Date()
             const { processEventBatch } = pluginConfig.vm?.methods || {}
             if (processEventBatch && returnedEvents.length > 0) {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -208,7 +208,7 @@ export async function runPlugins(server: PluginsServer, event: PluginEvent): Pro
     const pluginsToRun = getPluginsForTeam(server, event.team_id)
     let returnedEvent: PluginEvent | null = event
 
-    for (const pluginConfig of pluginsToRun.reverse()) {
+    for (const pluginConfig of pluginsToRun) {
         if (pluginConfig.vm?.methods?.processEvent) {
             const timer = new Date()
 


### PR DESCRIPTION
## Changes

- We were reversing the order of plugins on every run. Doh!

![image](https://user-images.githubusercontent.com/53387/109814013-574dfa00-7c2e-11eb-8676-9e9c06f8078e.png)

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
