### PR TITLE
Add support for FOSS webhook task

### DIFF
--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -449,10 +449,13 @@ export class EventsProcessor {
     }
 
     private async shouldSendHooksTask(team: Team): Promise<boolean> {
+        // Webhooks
         if (team.slack_incoming_webhook) {
             return true
         }
+        // REST hooks (Zapier)
         if (!this.pluginsServer.KAFKA_ENABLED) {
+            // REST hooks are EE-only
             return false
         }
         const timeout = timeoutGuard(`Still running "shouldSendHooksTask". Timeout warning after 30 sec!`)
@@ -510,43 +513,54 @@ export class EventsProcessor {
                     },
                 ],
             })
+            if (await this.shouldSendHooksTask(team)) {
+                this.pluginsServer.statsd?.increment(`hooks.send_task`)
+                this.celery.sendTask(
+                    'ee.tasks.webhooks_ee.post_event_to_webhook_ee',
+                    [
+                        {
+                            event,
+                            properties,
+                            distinct_id: distinctId,
+                            timestamp,
+                            elements_chain: elementsChain,
+                        },
+                        team.id,
+                        siteUrl,
+                    ],
+                    {}
+                )
+            }
         } else {
             let elementsHash = ''
             if (elements && elements.length > 0) {
                 elementsHash = await this.db.createElementGroup(elements, team.id)
             }
-            await this.db.postgresQuery(
-                'INSERT INTO posthog_event (created_at, event, distinct_id, properties, team_id, timestamp, elements, elements_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
-                [
-                    data.createdAt,
-                    data.event,
-                    distinctId,
-                    data.properties,
-                    data.teamId,
-                    data.timestamp,
-                    JSON.stringify(elements || []),
-                    elementsHash,
-                ]
-            )
-        }
-
-        if (await this.shouldSendHooksTask(team)) {
-            this.pluginsServer.statsd?.increment(`hooks.send_task`)
-            this.celery.sendTask(
-                'ee.tasks.webhooks_ee.post_event_to_webhook_ee',
-                [
-                    {
-                        event,
-                        properties,
-                        distinct_id: distinctId,
-                        timestamp,
-                        elements_chain: elementsChain,
-                    },
-                    team.id,
-                    siteUrl,
-                ],
-                {}
-            )
+            const event = (
+                await this.db.postgresQuery(
+                    'INSERT INTO posthog_event (created_at, event, distinct_id, properties, team_id, timestamp, elements, elements_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
+                    [
+                        data.createdAt,
+                        data.event,
+                        distinctId,
+                        data.properties,
+                        data.teamId,
+                        data.timestamp,
+                        JSON.stringify(elements || []),
+                        elementsHash,
+                    ]
+                )
+            ).rows[0]
+            if (await this.shouldSendHooksTask(team)) {
+                this.pluginsServer.statsd?.increment(`hooks.send_task`)
+                this.celery.sendTask(
+                    this.kafkaProducer
+                        ? 'ee.tasks.webhooks_ee.post_event_to_webhook_ee'
+                        : 'posthog.tasks.webhooks.post_event_to_webhook',
+                    [event.id, siteUrl],
+                    {}
+                )
+            }
         }
 
         return data

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -553,13 +553,7 @@ export class EventsProcessor {
             ).rows[0]
             if (await this.shouldSendHooksTask(team)) {
                 this.pluginsServer.statsd?.increment(`hooks.send_task`)
-                this.celery.sendTask(
-                    this.kafkaProducer
-                        ? 'ee.tasks.webhooks_ee.post_event_to_webhook_ee'
-                        : 'posthog.tasks.webhooks.post_event_to_webhook',
-                    [event.id, siteUrl],
-                    {}
-                )
+                this.celery.sendTask('posthog.tasks.webhooks.post_event_to_webhook', [event.id, siteUrl], {})
             }
         }
 

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -12,7 +12,6 @@ import { DB } from '../db'
 import { Event as EventProto, IEvent } from '../idl/protos'
 import { status } from '../status'
 import {
-    CohortPeople,
     Element,
     Person,
     PersonDistinctId,
@@ -553,7 +552,11 @@ export class EventsProcessor {
             )
             if (await this.shouldSendHooksTask(team)) {
                 this.pluginsServer.statsd?.increment(`hooks.send_task`)
-                this.celery.sendTask('posthog.tasks.webhooks.post_event_to_webhook', [event.id, siteUrl], {})
+                this.celery.sendTask(
+                    'posthog.tasks.calculate_action.calculate_actions_for_event',
+                    [event.id, siteUrl],
+                    {}
+                )
             }
         }
 

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -12,6 +12,7 @@ import { DB } from '../db'
 import { Event as EventProto, IEvent } from '../idl/protos'
 import { status } from '../status'
 import {
+    CohortPeople,
     Element,
     Person,
     PersonDistinctId,
@@ -552,11 +553,7 @@ export class EventsProcessor {
             )
             if (await this.shouldSendHooksTask(team)) {
                 this.pluginsServer.statsd?.increment(`hooks.send_task`)
-                this.celery.sendTask(
-                    'posthog.tasks.calculate_action.calculate_actions_for_event',
-                    [event.id, siteUrl],
-                    {}
-                )
+                this.celery.sendTask('posthog.tasks.webhooks.post_event_to_webhook', [event.id, siteUrl], {})
             }
         }
 

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -536,21 +536,21 @@ export class EventsProcessor {
             if (elements && elements.length > 0) {
                 elementsHash = await this.db.createElementGroup(elements, team.id)
             }
-            const event = (
-                await this.db.postgresQuery(
-                    'INSERT INTO posthog_event (created_at, event, distinct_id, properties, team_id, timestamp, elements, elements_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
-                    [
-                        data.createdAt,
-                        data.event,
-                        distinctId,
-                        data.properties,
-                        data.teamId,
-                        data.timestamp,
-                        JSON.stringify(elements || []),
-                        elementsHash,
-                    ]
-                )
-            ).rows[0]
+            const {
+                rows: [event],
+            } = await this.db.postgresQuery(
+                'INSERT INTO posthog_event (created_at, event, distinct_id, properties, team_id, timestamp, elements, elements_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
+                [
+                    data.createdAt,
+                    data.event,
+                    distinctId,
+                    data.properties,
+                    data.teamId,
+                    data.timestamp,
+                    JSON.stringify(elements || []),
+                    elementsHash,
+                ]
+            )
             if (await this.shouldSendHooksTask(team)) {
                 this.pluginsServer.statsd?.increment(`hooks.send_task`)
                 this.celery.sendTask('posthog.tasks.webhooks.post_event_to_webhook', [event.id, siteUrl], {})


### PR DESCRIPTION
## Changes

Resolves the issue where webhooks don't for FOSS PostHog users who have opted into plugins.

## Checklist

-   [ ] Jest tests
