### PR TITLE
Try a different way of detecting Heroku

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -104,7 +104,7 @@ export async function createServer(
 
     const postgres = new Pool({
         connectionString: serverConfig.DATABASE_URL,
-        ssl: process.env.DEPLOYMENT?.startsWith('Heroku')
+        ssl: process.env.DYNO // Means we are on Heroku
             ? {
                   rejectUnauthorized: false,
               }


### PR DESCRIPTION
## Changes

The `DEPLOYMENT` var is faulty, as it's not guaranteed to be there. It even caused an outage for a user. The `DYNO` env var seems to be built-in for Heroku, offering better reliability.