### PR TITLE
Set explicit limits to postgres connection pool:

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -391,6 +391,8 @@ export async function createRedis(serverConfig: PluginsServerConfig): Promise<Re
 export function createPostgresPool(serverConfig: PluginsServerConfig): Pool {
     const postgres = new Pool({
         connectionString: serverConfig.DATABASE_URL,
+        idleTimeoutMillis: 500,
+        max: 10,
         ssl: process.env.DYNO // Means we are on Heroku
             ? {
                   rejectUnauthorized: false,


### PR DESCRIPTION
https://node-postgres.com/api/pool#poolquery

- `idleTimeoutMillis` is set to 500ms to make sure we return
connections/don't block other apps.
- `max` is set to 10 (per worker) to make sure we don't leak connections
indefinetly.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
