### PR TITLE
Batch kafka producer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | KAFKA_CLIENT_CERT_B64         | Kafka certificate in Base64                                | `null`                                |
 | KAFKA_CLIENT_CERT_KEY_B64     | Kafka certificate key in Base64                            | `null`                                |
 | KAFKA_TRUSTED_CERT_B64        | Kafka trusted CA in Base64                                 | `null`                                |
+| KAFKA_PRODUCER_MAX_QUEUE_SIZE | Kafka producer queue max size before flushing              | `1000`                                |
+| KAFKA_FLUSH_FREQUENCY_MS      | Kafka producer queue max duration before flushing          | `500`                                 |
 | DISABLE_WEB                   | whether to disable web server                              | `true`                                |
 | WEB_PORT                      | port for web server to listen on                           | `3008`                                |
 | WEB_HOSTNAME                  | hostname for web server to listen on                       | `'0.0.0.0'`                           |

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CLIENT_CERT_KEY_B64: null,
         KAFKA_TRUSTED_CERT_B64: null,
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
+        KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv ? 0 : 1000,
+        KAFKA_FLUSH_FREQUENCY_MS: 500,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',
         BASE_DIR: '.',

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_TRUSTED_CERT_B64: null,
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv ? 0 : 1000,
-        KAFKA_FLUSH_FREQUENCY_MS: 200,
+        KAFKA_FLUSH_FREQUENCY_MS: 500,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',
         BASE_DIR: '.',

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_TRUSTED_CERT_B64: null,
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv ? 0 : 1000,
-        KAFKA_FLUSH_FREQUENCY_MS: 500,
+        KAFKA_FLUSH_FREQUENCY_MS: 200,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',
         BASE_DIR: '.',

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,7 +7,6 @@ import { Producer, ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { Pool, PoolClient, QueryConfig, QueryResult, QueryResultRow } from 'pg'
 
-import { defaultConfig } from './config'
 import { KAFKA_PERSON, KAFKA_PERSON_UNIQUE_ID } from './ingestion/topics'
 import { chainToElements, hashElements, timeoutGuard, unparsePersonPartial } from './ingestion/utils'
 import {
@@ -61,10 +60,10 @@ export class DB {
     constructor(
         postgres: Pool,
         redisPool: GenericPool<Redis.Redis>,
-        kafkaProducer?: Producer,
-        clickhouse?: ClickHouse,
-        statsd?: StatsD,
-        serverConfig: PluginsServerConfig = defaultConfig
+        kafkaProducer: Producer | undefined,
+        clickhouse: ClickHouse | undefined,
+        statsd: StatsD | undefined,
+        serverConfig: PluginsServerConfig
     ) {
         this.postgres = postgres
         this.redisPool = redisPool

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -129,7 +129,7 @@ export class KafkaQueue implements Queue {
 
         status.info(
             '🧩',
-            `Kafka Batch of ${pluginEvents.length} events completed in ${
+            `Kafka batch of ${pluginEvents.length} events completed in ${
                 new Date().valueOf() - batchStartTimer.valueOf()
             }ms (plugins: ${batchIngestionTimer.valueOf() - batchStartTimer.valueOf()}ms, ingestion: ${
                 new Date().valueOf() - batchIngestionTimer.valueOf()
@@ -157,7 +157,7 @@ export class KafkaQueue implements Queue {
                     try {
                         await this.eachBatch(payload)
                     } catch (error) {
-                        status.info('💀', `Kafka Batch of ${payload.batch.messages.length} events failed!`)
+                        status.info('💀', `Kafka batch of ${payload.batch.messages.length} events failed!`)
                         Sentry.captureException(error)
                         throw error
                     }

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -514,7 +514,7 @@ export class EventsProcessor {
         }
 
         if (this.kafkaProducer) {
-            await this.db.sendKafkaMessage({
+            await this.db.queueKafkaMessage({
                 topic: KAFKA_EVENTS,
                 messages: [
                     {
@@ -595,7 +595,7 @@ export class EventsProcessor {
         }
 
         if (this.kafkaProducer) {
-            await this.db.sendKafkaMessage({
+            await this.db.queueKafkaMessage({
                 topic: KAFKA_SESSION_RECORDING_EVENTS,
                 messages: [{ key: uuid, value: Buffer.from(JSON.stringify(data)) }],
             })

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,6 +156,8 @@ export async function createServer(
     server.eventsProcessor = new EventsProcessor(server as PluginsServer)
 
     const closeServer = async () => {
+        clearInterval(db.kafkaFlushInterval)
+        await db.flushKafkaMessages()
         await kafkaProducer?.disconnect()
         await redisPool.drain()
         await redisPool.clear()
@@ -294,5 +296,6 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
     // Wait two seconds for any running workers to stop.
     // TODO: better "wait until everything is done"
     await delay(2000)
+    await Promise.race([piscina.broadcastTask({ task: 'flushKafkaMessages' }), delay(2000)])
     await piscina.destroy()
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -134,7 +134,7 @@ export async function createServer(
         }
     }
 
-    const db = new DB(postgres, redisPool, kafkaProducer, clickhouse, statsd)
+    const db = new DB(postgres, redisPool, kafkaProducer, clickhouse, statsd, serverConfig)
 
     const server: Omit<PluginsServer, 'eventsProcessor'> = {
         ...serverConfig,

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -32,7 +32,7 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
                 throw new Error('kafkaProducer not configured!')
             }
             // ignore the promise, run in the background just like with celery
-            void server.db.sendKafkaMessage({
+            void server.db.queueKafkaMessage({
                 topic: server.KAFKA_CONSUMPTION_TOPIC!,
                 messages: [
                     {

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -4,7 +4,7 @@ import { runPlugins, runPluginsOnBatch, runPluginTask } from '../plugins/run'
 import { loadSchedule, setupPlugins } from '../plugins/setup'
 import { createServer } from '../server'
 import { status } from '../status'
-import { PluginsServerConfig } from '../types'
+import { PluginsServer, PluginsServerConfig } from '../types'
 import { cloneObject } from '../utils'
 
 type TaskWorker = ({ task, args }: { task: string; args: any }) => Promise<any>
@@ -21,43 +21,45 @@ export async function createWorker(config: PluginsServerConfig, threadId: number
         process.on(signal, closeServer)
     }
 
-    return async ({ task, args }) => {
-        const timer = new Date()
-        let response
+    return createTaskRunner(server)
+}
 
-        if (task === 'hello') {
-            response = `hello ${args[0]}!`
-        }
-        if (task === 'processEvent') {
-            const processedEvent = await runPlugins(server, args.event)
-            // must clone the object, as we may get from VM2 something like { ..., properties: Proxy {} }
-            response = cloneObject(processedEvent as Record<string, any>)
-        }
-        if (task === 'processEventBatch') {
-            const processedEvents = await runPluginsOnBatch(server, args.batch)
-            // must clone the object, as we may get from VM2 something like { ..., properties: Proxy {} }
-            response = cloneObject(processedEvents as any[])
-        }
-        if (task === 'getPluginSchedule') {
-            response = cloneObject(server.pluginSchedule)
-        }
-        if (task === 'ingestEvent') {
-            response = cloneObject(await ingestEvent(server, args.event))
-        }
-        if (task.startsWith('runEvery')) {
-            const { pluginConfigId } = args
-            response = cloneObject(await runPluginTask(server, task, pluginConfigId))
-        }
-        if (task === 'reloadPlugins') {
-            await setupPlugins(server)
-        }
-        if (task === 'reloadSchedule') {
-            await loadSchedule(server)
-        }
-        if (task === 'flushKafkaMessages') {
-            await server.db.flushKafkaMessages()
-        }
-        server.statsd?.timing(`piscina_task.${task}`, timer)
-        return response
+export const createTaskRunner = (server: PluginsServer): TaskWorker => async ({ task, args }) => {
+    const timer = new Date()
+    let response
+
+    if (task === 'hello') {
+        response = `hello ${args[0]}!`
     }
+    if (task === 'processEvent') {
+        const processedEvent = await runPlugins(server, args.event)
+        // must clone the object, as we may get from VM2 something like { ..., properties: Proxy {} }
+        response = cloneObject(processedEvent as Record<string, any>)
+    }
+    if (task === 'processEventBatch') {
+        const processedEvents = await runPluginsOnBatch(server, args.batch)
+        // must clone the object, as we may get from VM2 something like { ..., properties: Proxy {} }
+        response = cloneObject(processedEvents as any[])
+    }
+    if (task === 'getPluginSchedule') {
+        response = cloneObject(server.pluginSchedule)
+    }
+    if (task === 'ingestEvent') {
+        response = cloneObject(await ingestEvent(server, args.event))
+    }
+    if (task.startsWith('runEvery')) {
+        const { pluginConfigId } = args
+        response = cloneObject(await runPluginTask(server, task, pluginConfigId))
+    }
+    if (task === 'reloadPlugins') {
+        await setupPlugins(server)
+    }
+    if (task === 'reloadSchedule') {
+        await loadSchedule(server)
+    }
+    if (task === 'flushKafkaMessages') {
+        await server.db.flushKafkaMessages()
+    }
+    server.statsd?.timing(`piscina_task.${task}`, timer)
+    return response
 }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -54,6 +54,9 @@ export async function createWorker(config: PluginsServerConfig, threadId: number
         if (task === 'reloadSchedule') {
             await loadSchedule(server)
         }
+        if (task === 'flushKafkaMessages') {
+            await server.db.flushKafkaMessages()
+        }
         server.statsd?.timing(`piscina_task.${task}`, timer)
         return response
     }

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -53,6 +53,7 @@ describe('e2e clickhouse ingestion', () => {
         expect((await server.db.fetchEvents()).length).toBe(0)
         const uuid = new UUIDT().toString()
         posthog.capture('custom event', { name: 'haha', uuid })
+        await server.db.flushKafkaMessages()
         await delayUntilEventIngested(() => server.db.fetchEvents())
         const events = await server.db.fetchEvents()
         expect(events.length).toBe(1)

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -1,16 +1,24 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
+import { mocked } from 'ts-jest/utils'
 
 import Client from '../../src/celery/client'
+import { ingestEvent } from '../../src/ingestion/ingest-event'
+import { runPlugins, runPluginsOnBatch, runPluginTask } from '../../src/plugins/run'
+import { loadSchedule, setupPlugins } from '../../src/plugins/setup'
 import { startPluginsServer } from '../../src/server'
 import { loadPluginSchedule } from '../../src/services/schedule'
 import { LogLevel } from '../../src/types'
 import { delay, UUIDT } from '../../src/utils'
 import { makePiscina } from '../../src/worker/piscina'
+import { createTaskRunner } from '../../src/worker/worker'
 import { resetTestDatabase } from '../helpers/sql'
 import { setupPiscina } from '../helpers/worker'
 
 jest.mock('../../src/sql')
 jest.mock('../../src/status')
+jest.mock('../../src/ingestion/ingest-event')
+jest.mock('../../src/plugins/run')
+jest.mock('../../src/plugins/setup')
 jest.setTimeout(600000) // 600 sec timeout
 
 function createEvent(index = 0): PluginEvent {
@@ -199,4 +207,88 @@ test('pause the queue if too many tasks', async () => {
 
     await pluginsServer.server.redisPool.release(redis)
     await pluginsServer.stop()
+})
+
+describe('createTaskRunner()', () => {
+    let taskRunner: any
+    let server: any
+
+    beforeEach(() => {
+        server = { mock: 'server' }
+        taskRunner = createTaskRunner(server)
+    })
+
+    it('handles `hello` task', async () => {
+        expect(await taskRunner({ task: 'hello', args: ['world'] })).toEqual('hello world!')
+    })
+
+    it('handles `processEvent` task', async () => {
+        mocked(runPlugins).mockReturnValue('runPlugins response' as any)
+
+        expect(await taskRunner({ task: 'processEvent', args: { event: 'someEvent' } })).toEqual('runPlugins response')
+
+        expect(runPlugins).toHaveBeenCalledWith(server, 'someEvent')
+    })
+
+    it('handles `processEventBatch` task', async () => {
+        mocked(runPluginsOnBatch).mockReturnValue(['runPluginsOnBatch response'] as any)
+
+        expect(await taskRunner({ task: 'processEventBatch', args: { batch: 'someBatch' } })).toEqual([
+            'runPluginsOnBatch response',
+        ])
+
+        expect(runPluginsOnBatch).toHaveBeenCalledWith(server, 'someBatch')
+    })
+
+    it('handles `getPluginSchedule` task', async () => {
+        server.pluginSchedule = { runEveryDay: [66] }
+
+        expect(await taskRunner({ task: 'getPluginSchedule' })).toEqual(server.pluginSchedule)
+    })
+
+    it('handles `ingestEvent` task', async () => {
+        mocked(ingestEvent).mockReturnValue('ingestEvent response' as any)
+
+        expect(await taskRunner({ task: 'ingestEvent', args: { event: 'someEvent' } })).toEqual('ingestEvent response')
+
+        expect(ingestEvent).toHaveBeenCalledWith(server, 'someEvent')
+    })
+
+    it('handles `ingestEvent` task', async () => {
+        mocked(ingestEvent).mockReturnValue('ingestEvent response' as any)
+
+        expect(await taskRunner({ task: 'ingestEvent', args: { event: 'someEvent' } })).toEqual('ingestEvent response')
+
+        expect(ingestEvent).toHaveBeenCalledWith(server, 'someEvent')
+    })
+
+    it('handles `runEvery` tasks', async () => {
+        mocked(runPluginTask).mockImplementation((server, task, pluginId) => Promise.resolve(`${task} for ${pluginId}`))
+
+        expect(await taskRunner({ task: 'runEveryMinute', args: { pluginConfigId: 1 } })).toEqual(
+            'runEveryMinute for 1'
+        )
+        expect(await taskRunner({ task: 'runEveryHour', args: { pluginConfigId: 1 } })).toEqual('runEveryHour for 1')
+        expect(await taskRunner({ task: 'runEveryDay', args: { pluginConfigId: 1 } })).toEqual('runEveryDay for 1')
+    })
+
+    it('handles `reloadPlugins` task', async () => {
+        await taskRunner({ task: 'reloadPlugins' })
+
+        expect(setupPlugins).toHaveBeenCalled()
+    })
+
+    it('handles `reloadSchedule` task', async () => {
+        await taskRunner({ task: 'reloadSchedule' })
+
+        expect(loadSchedule).toHaveBeenCalled()
+    })
+
+    it('handles `flushKafkaMessages` task', async () => {
+        server.db = { flushKafkaMessages: jest.fn() }
+
+        await taskRunner({ task: 'flushKafkaMessages' })
+
+        expect(server.db.flushKafkaMessages).toHaveBeenCalled()
+    })
 })

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -143,6 +143,7 @@ test('pause the queue if too many tasks', async () => {
         uuid: new UUIDT().toString(),
     })
 
+    await delay(1000)
     const baseCompleted = pluginsServer.piscina.completed
 
     expect(pluginsServer.piscina.queueSize).toBe(0)


### PR DESCRIPTION
Updated kafka producer to send messages in batches. Updated worker.ts tests as well since was having trouble with some of the instability.

This should speed up plugin server significantly. Future optimizations would include making sure we only send kafka messages from main thread to get more out of batching, though I am not sure I can follow the code well here to make sure we don't already.

@Twixes did not update worker.ts to use switch - some if conditions are not using plain equals there but more complicated conditions.

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
-   [x] Jest tests
