### PR TITLE
 Use DB#sendKafkaMessage in posthog extension

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -123,6 +123,7 @@ export class DB {
     // Kafka
 
     public async sendKafkaMessage(kafkaMessage: ProducerRecord): Promise<void> {
+        kafkaMessage.acks = 1 // Only wait for leader broker to ack, instead of all brokers (which is 3 on Heroku)
         return this.instrumentQuery('query.kafka_send', undefined, async () => {
             if (!this.kafkaProducer) {
                 throw new Error('Kafka connection has not been provided!')

--- a/src/db.ts
+++ b/src/db.ts
@@ -123,7 +123,6 @@ export class DB {
     // Kafka
 
     public async sendKafkaMessage(kafkaMessage: ProducerRecord): Promise<void> {
-        kafkaMessage.acks = 1 // Only wait for leader broker to ack, instead of all brokers (which is 3 on Heroku)
         return this.instrumentQuery('query.kafka_send', undefined, async () => {
             if (!this.kafkaProducer) {
                 throw new Error('Kafka connection has not been provided!')

--- a/src/vm/extensions/posthog.ts
+++ b/src/vm/extensions/posthog.ts
@@ -32,7 +32,7 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
                 throw new Error('kafkaProducer not configured!')
             }
             // ignore the promise, run in the background just like with celery
-            void server.kafkaProducer.send({
+            void server.db.sendKafkaMessage({
                 topic: server.KAFKA_CONSUMPTION_TOPIC!,
                 messages: [
                     {


### PR DESCRIPTION
## Changes

Was reading https://kafka.js.org/docs/producing and recalled `acks`. This setting's default means that all brokers must receive the message before it's accepted, but we may not need that. Instead let's try only requiring ack from the leader broker. This should help with produce latency.
