### PR TITLE
Send an (estimated) latency metric to statsd

### DIFF
--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -75,6 +75,12 @@ export class EventsProcessor {
         const personUuid = new UUIDT().toString()
 
         const ts = this.handleTimestamp(data, now, sentAt)
+        // Send latency estimate to statsd, but ignore events set in the future.
+        const latencyEstimate = (sentAt || ts).toMillis() - singleSaveTimer.getMilliseconds()
+        if (latencyEstimate > 0) {
+            this.pluginsServer.statsd?.timing('process_event.latency', latencyEstimate)
+        }
+
         const timeout1 = timeoutGuard(
             `Still running "handleIdentifyOrAlias". Timeout warning after 30 sec! ${eventUuid}`
         )


### PR DESCRIPTION
This should allow us to graph min(metric) over mean(instances).

Couple of things make this a bit tricky/hard to be 100% confident in:
1. Different consumers will have different latencies
2. sentAt is not always set
3. ts can be in the future
4. Clock drift schenanigans

However, since we don't need a _accurate_ estimate (to the second) but
rather e.g. whether we're OK or 2 hours behind this should work.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
