### PR TITLE
Decrease max batch sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | KAFKA_CLIENT_CERT_B64         | Kafka certificate in Base64                                | `null`                                |
 | KAFKA_CLIENT_CERT_KEY_B64     | Kafka certificate key in Base64                            | `null`                                |
 | KAFKA_TRUSTED_CERT_B64        | Kafka trusted CA in Base64                                 | `null`                                |
-| KAFKA_PRODUCER_MAX_QUEUE_SIZE | Kafka producer queue max size before flushing              | `1000`                                |
+| KAFKA_PRODUCER_MAX_QUEUE_SIZE | Kafka producer queue max size before flushing              | `20`                                  |
 | KAFKA_FLUSH_FREQUENCY_MS      | Kafka producer queue max duration before flushing          | `500`                                 |
 | DISABLE_WEB                   | whether to disable web server                              | `true`                                |
 | WEB_PORT                      | port for web server to listen on                           | `3008`                                |

--- a/src/db.ts
+++ b/src/db.ts
@@ -155,24 +155,14 @@ export class DB {
                 throw new Error('Kafka connection has not been provided!')
             }
 
-            const batches: Record<string, ProducerRecord> = {}
-            for (const { topic, messages } of this.kafkaMessageQueue) {
-                if (!batches[topic]) {
-                    batches[topic] = {
-                        topic,
-                        messages: [],
-                    }
-                }
-                batches[topic].messages = batches[topic].messages.concat(messages)
-            }
-
+            const messages = this.kafkaMessageQueue
             this.kafkaMessageQueue = []
             this.lastFlushTime = new Date()
 
             const timeout = timeoutGuard(`Kafka message sending delayed. Waiting over 30 sec to send messages.`)
             try {
                 await this.kafkaProducer!.sendBatch({
-                    topicMessages: Object.values(batches),
+                    topicMessages: messages,
                 })
             } finally {
                 clearTimeout(timeout)


### PR DESCRIPTION
- Remove unneeded code
    
    Seems like kafkajs already does this under the hood: https://github.com/tulios/kafkajs/blob/d13acd58f693bef5f2460ade036757d6314e4710/src/producer/messageProducer.js#L83-L93

- Decrease max batch size(s)
    
    We're seeing errors like `The request included a message larger than the
    max message size the server will accept` due to adding batching.
    
    This is an attempt to see whether reducing max batch sizes will fix
    things.



## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
