### PR TITLE
Use structured logging over string interpolation

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -86,7 +86,7 @@ export class DB {
         tag?: string
     ): Promise<QueryResult<R>> {
         return this.instrumentQuery('query.postgres', tag, async () => {
-            const timeout = timeoutGuard(`Postgres slow query warning after 30 sec: ${queryTextOrConfig}`)
+            const timeout = timeoutGuard('Postgres slow query warning after 30 sec', { queryTextOrConfig, values })
             try {
                 return await this.postgres.query(queryTextOrConfig, values)
             } finally {
@@ -126,7 +126,7 @@ export class DB {
             if (!this.clickhouse) {
                 throw new Error('ClickHouse connection has not been provided to this DB instance!')
             }
-            const timeout = timeoutGuard(`ClickHouse slow query warning after 30 sec: ${query}`)
+            const timeout = timeoutGuard('ClickHouse slow query warning after 30 sec', { query })
             try {
                 return await this.clickhouse.querying(query, options)
             } finally {
@@ -169,7 +169,7 @@ export class DB {
             this.kafkaMessageQueue = []
             this.lastFlushTime = new Date()
 
-            const timeout = timeoutGuard(`Kafka message sending delayed. Waiting over 30 sec to send messages.`)
+            const timeout = timeoutGuard('Kafka message sending delayed. Waiting over 30 sec to send messages.')
             try {
                 await this.kafkaProducer!.sendBatch({
                     topicMessages: Object.values(batches),
@@ -187,7 +187,7 @@ export class DB {
 
         return this.instrumentQuery('query.regisGet', undefined, async () => {
             const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard(`Getting redis key delayed. Waiting over 30 sec to get key: ${key}`)
+            const timeout = timeoutGuard('Getting redis key delayed. Waiting over 30 sec to get key.', { key })
             try {
                 const value = await tryTwice(
                     async () => await client.get(key),
@@ -216,7 +216,7 @@ export class DB {
 
         return this.instrumentQuery('query.redisSet', undefined, async () => {
             const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard(`Setting redis key delayed. Waiting over 30 sec to set key: ${key}`)
+            const timeout = timeoutGuard('Setting redis key delayed. Waiting over 30 sec to set key', { key })
             try {
                 const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
                 if (ttlSeconds) {
@@ -234,7 +234,7 @@ export class DB {
     public async redisIncr(key: string): Promise<number> {
         return this.instrumentQuery('query.redisIncr', undefined, async () => {
             const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard(`Incrementing redis key delayed. Waiting over 30 sec to incr key: ${key}`)
+            const timeout = timeoutGuard('Incrementing redis key delayed. Waiting over 30 sec to incr key', { key })
             try {
                 return await client.incr(key)
             } finally {
@@ -247,7 +247,7 @@ export class DB {
     public async redisExpire(key: string, ttlSeconds: number): Promise<boolean> {
         return this.instrumentQuery('query.redisExpire', undefined, async () => {
             const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard(`Expiring redis key delayed. Waiting over 30 sec to expire key: ${key}`)
+            const timeout = timeoutGuard('Expiring redis key delayed. Waiting over 30 sec to expire key', { key })
             try {
                 return (await client.expire(key, ttlSeconds)) === 1
             } finally {
@@ -262,7 +262,7 @@ export class DB {
 
         return this.instrumentQuery('query.redisLPush', undefined, async () => {
             const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard(`LPushing redis key delayed. Waiting over 30 sec to lpush key: ${key}`)
+            const timeout = timeoutGuard('LPushing redis key delayed. Waiting over 30 sec to lpush key', { key })
             try {
                 const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
                 return await client.lpush(key, serializedValue)
@@ -276,9 +276,10 @@ export class DB {
     public async redisBRPop(key1: string, key2: string): Promise<[string, string]> {
         return this.instrumentQuery('query.redisBRPop', undefined, async () => {
             const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard(
-                `BRPoping redis key delayed. Waiting over 30 sec to brpop keys: ${key1}, ${key2}`
-            )
+            const timeout = timeoutGuard('BRPoping redis key delayed. Waiting over 30 sec to brpop keys', {
+                key1,
+                key2,
+            })
             try {
                 return await client.brpop(key1, key2)
             } finally {

--- a/src/ingestion/ingest-event.ts
+++ b/src/ingestion/ingest-event.ts
@@ -9,9 +9,9 @@ import { timeoutGuard } from './utils'
 export type IngestEventResponse = { success?: boolean; error?: string }
 
 export async function ingestEvent(server: PluginsServer, event: PluginEvent): Promise<IngestEventResponse> {
-    const timeout = timeoutGuard(
-        `Still ingesting event inside worker. Timeout warning after 30 sec! ${JSON.stringify(event)}`
-    )
+    const timeout = timeoutGuard('Still ingesting event inside worker. Timeout warning after 30 sec!', {
+        event: JSON.stringify(event),
+    })
     try {
         const { distinct_id, ip, site_url, team_id, now, sent_at, uuid } = event
         await server.eventsProcessor.processEvent(

--- a/src/ingestion/kafka-queue.ts
+++ b/src/ingestion/kafka-queue.ts
@@ -62,9 +62,9 @@ export class KafkaQueue implements Queue {
             )
         )
 
-        const processingTimeout = timeoutGuard(
-            `Still running plugins on ${pluginEvents.length} events. Timeout warning after 30 sec!`
-        )
+        const processingTimeout = timeoutGuard('Still running plugins on events. Timeout warning after 30 sec!', {
+            eventCount: pluginEvents.length,
+        })
         const processingBatches = groupIntoBatches(pluginEvents, maxBatchSize)
         const processedEvents = (
             await Promise.all(
@@ -88,14 +88,14 @@ export class KafkaQueue implements Queue {
             (a, b) => (uuidOrder.get(a.uuid!) || pluginEvents.length) - (uuidOrder.get(b.uuid!) || pluginEvents.length)
         )
 
-        const ingestionTimeout = timeoutGuard(
-            `Still ingesting ${processedEvents.length} events. Timeout warning after 30 sec!`
-        )
+        const ingestionTimeout = timeoutGuard('Still ingesting events. Timeout warning after 30 sec!', {
+            eventCount: processedEvents.length,
+        })
 
         const ingestOneEvent = async (event: PluginEvent) => {
-            const singleIngestionTimeout = timeoutGuard(
-                `After 30 seconds still ingesting event: ${JSON.stringify(event)}`
-            )
+            const singleIngestionTimeout = timeoutGuard('After 30 seconds still ingesting event', {
+                event: JSON.stringify(event),
+            })
             const singleIngestionTimer = new Date()
             try {
                 await this.saveEvent(event)

--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -60,9 +60,9 @@ export class EventsProcessor {
             throw new Error(`Not a valid UUID: "${eventUuid}"`)
         }
         const singleSaveTimer = new Date()
-        const timeout = timeoutGuard(
-            `Still inside "EventsProcessor.processEvent". Timeout warning after 30 sec! ${JSON.stringify(data)}`
-        )
+        const timeout = timeoutGuard('Still inside "EventsProcessor.processEvent". Timeout warning after 30 sec!', {
+            event: JSON.stringify(data),
+        })
 
         const properties: Properties = data.properties ?? {}
         if (data['$set']) {
@@ -75,9 +75,9 @@ export class EventsProcessor {
         const personUuid = new UUIDT().toString()
 
         const ts = this.handleTimestamp(data, now, sentAt)
-        const timeout1 = timeoutGuard(
-            `Still running "handleIdentifyOrAlias". Timeout warning after 30 sec! ${eventUuid}`
-        )
+        const timeout1 = timeoutGuard('Still running "handleIdentifyOrAlias". Timeout warning after 30 sec!', {
+            eventUuid,
+        })
         await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
         clearTimeout(timeout1)
 
@@ -85,7 +85,8 @@ export class EventsProcessor {
 
         if (data['event'] === '$snapshot') {
             const timeout2 = timeoutGuard(
-                `Still running "createSessionRecordingEvent". Timeout warning after 30 sec! ${eventUuid}`
+                'Still running "createSessionRecordingEvent". Timeout warning after 30 sec!',
+                { eventUuid }
             )
             result = await this.createSessionRecordingEvent(
                 eventUuid,
@@ -98,7 +99,7 @@ export class EventsProcessor {
             this.pluginsServer.statsd?.timing('kafka_queue.single_save.snapshot', singleSaveTimer)
             clearTimeout(timeout2)
         } else {
-            const timeout3 = timeoutGuard(`Still running "captureEE". Timeout warning after 30 sec! ${eventUuid}`)
+            const timeout3 = timeoutGuard('Still running "captureEE". Timeout warning after 30 sec!', { eventUuid })
             result = await this.captureEE(
                 eventUuid,
                 personUuid,
@@ -392,9 +393,10 @@ export class EventsProcessor {
     }
 
     private async storeNamesAndProperties(team: Team, event: string, properties: Properties): Promise<void> {
-        const timeout = timeoutGuard(
-            `Still running "storeNamesAndProperties". Timeout warning after 30 sec! Event: ${event}. Ingested: ${team.ingested_event}`
-        )
+        const timeout = timeoutGuard('Still running "storeNamesAndProperties". Timeout warning after 30 sec!', {
+            event: event,
+            ingested: team.ingested_event,
+        })
         // In _capture we only prefetch a couple of fields in Team to avoid fetching too much data
         let save = false
         if (!team.ingested_event) {
@@ -434,7 +436,8 @@ export class EventsProcessor {
         }
         if (save) {
             const timeout2 = timeoutGuard(
-                `Still running "storeNamesAndProperties" save. Timeout warning after 30 sec! Event: ${event}`
+                'Still running "storeNamesAndProperties" save. Timeout warning after 30 sec!',
+                { event }
             )
             await this.db.postgresQuery(
                 `UPDATE posthog_team SET

--- a/src/ingestion/utils.ts
+++ b/src/ingestion/utils.ts
@@ -158,10 +158,14 @@ export function chainToElements(chain: string): Element[] {
     return elements
 }
 
-export function timeoutGuard(message: string, timeout = defaultConfig.TASK_TIMEOUT * 1000): NodeJS.Timeout {
+export function timeoutGuard(
+    message: string,
+    context?: Record<string, any>,
+    timeout = defaultConfig.TASK_TIMEOUT * 1000
+): NodeJS.Timeout {
     return setTimeout(() => {
-        console.log(`⌛⌛⌛ ${message}`)
-        Sentry.captureMessage(message)
+        console.log(`⌛⌛⌛ ${message}`, context)
+        Sentry.captureMessage(message, context ? { extra: context } : undefined)
     }, timeout)
 }
 


### PR DESCRIPTION
Motivation: Our sentry setup is a mess due to errors not getting
collapsed. They're not getting collapsed because our error strings are
unique every time.

The industry best practice for logging and error messages is to _avoid_
interpolating in strings, instead log fully as JSON or adding JSON at
the end. This allows:
- Sentry to collapse errors correctly
- Both sentry and logging tools to allow json search on variables within
the strings.

Read more here:
- https://stackify.com/what-is-structured-logging-and-why-developers-need-it/


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
