### PR TITLE
Send timing information w/ team_id to statsd

### DIFF
--- a/src/ingestion/process-event.ts
+++ b/src/ingestion/process-event.ts
@@ -96,7 +96,9 @@ export class EventsProcessor {
                 ts,
                 properties['$snapshot_data']
             )
-            this.pluginsServer.statsd?.timing('kafka_queue.single_save.snapshot', singleSaveTimer)
+            this.pluginsServer.statsd?.timing('kafka_queue.single_save.snapshot', singleSaveTimer, {
+                team_id: teamId.toString(),
+            })
             clearTimeout(timeout2)
         } else {
             const timeout3 = timeoutGuard('Still running "captureEE". Timeout warning after 30 sec!', { eventUuid })
@@ -112,7 +114,9 @@ export class EventsProcessor {
                 ts,
                 sentAt
             )
-            this.pluginsServer.statsd?.timing('kafka_queue.single_save.standard', singleSaveTimer)
+            this.pluginsServer.statsd?.timing('kafka_queue.single_save.standard', singleSaveTimer, {
+                team_id: teamId.toString(),
+            })
             clearTimeout(timeout3)
         }
         clearTimeout(timeout)

--- a/src/plugins/run.ts
+++ b/src/plugins/run.ts
@@ -59,6 +59,10 @@ export async function runPluginsOnBatch(server: PluginsServer, batch: PluginEven
                     server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.process_event_batch.ERROR`)
                 }
                 server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.process_event_batch`, timer)
+                server.statsd?.timing('plugin.process_event_batch', timer, 0.2, {
+                    plugin: pluginConfig.plugin?.name ?? '?',
+                    teamId: teamId.toString(),
+                })
             }
         }
 


### PR DESCRIPTION
Using sampling inside plugins to avoid overloading statsd server - this
data should sample relatively nicely.

Not 100% sure this won't fall over. Let's find out!

Related: https://github.com/PostHog/plugin-server/issues/156

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
