### PR TITLE
Add error handler for statsd

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -125,6 +125,12 @@ export async function createServer(
             host: serverConfig.STATSD_HOST,
             prefix: serverConfig.STATSD_PREFIX,
             telegraf: true,
+            errorHandler: (error) => {
+                status.warn('⚠️', 'StatsD error', error)
+                Sentry.captureException(error, {
+                    extra: { threadId },
+                })
+            },
         })
         // don't repeat the same info in each thread
         if (threadId === null) {


### PR DESCRIPTION
Noticing some missing metrics from statsd (from worker threads
specifically). Adding a error handler for that purpose.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
