### PR TITLE
Add caching for Team fetching

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -238,7 +238,6 @@ export interface Team {
     session_recording_opt_in: boolean
     plugins_opt_in: boolean
     ingested_event: boolean
-    __fetch_event_uuid?: string
 }
 
 /** Usable Element model. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,7 @@ export interface Team {
     session_recording_opt_in: boolean
     plugins_opt_in: boolean
     ingested_event: boolean
+    __fetch_event_uuid?: string
 }
 
 /** Usable Element model. */

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -357,7 +357,7 @@ export class EventsProcessor {
             }))
         }
 
-        const team: Team | null = await this.teamManager.fetchTeam(teamId)
+        const team: Team | null = await this.teamManager.fetchTeam(teamId, eventUuid)
 
         if (!team) {
             throw new Error(`No team found with ID ${teamId}. Can't ingest event.`)
@@ -367,7 +367,7 @@ export class EventsProcessor {
             properties['$ip'] = ip
         }
 
-        await this.teamManager.updateEventNamesAndProperties(teamId, event, properties, this.posthog)
+        await this.teamManager.updateEventNamesAndProperties(teamId, event, eventUuid, properties, this.posthog)
 
         const pdiSelectResult = await this.db.postgresQuery(
             'SELECT COUNT(*) AS pdicount FROM posthog_persondistinctid WHERE team_id = $1 AND distinct_id = $2',

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -367,7 +367,7 @@ export class EventsProcessor {
             properties['$ip'] = ip
         }
 
-        await this.storeNamesAndProperties(team, event, properties)
+        await this.teamManager.updateEventNamesAndProperties(teamId, event, properties, this.posthog)
 
         const pdiSelectResult = await this.db.postgresQuery(
             'SELECT COUNT(*) AS pdicount FROM posthog_persondistinctid WHERE team_id = $1 AND distinct_id = $2',
@@ -397,74 +397,6 @@ export class EventsProcessor {
         }
 
         return await this.createEvent(eventUuid, event, team, distinctId, properties, timestamp, elementsList, siteUrl)
-    }
-
-    private async storeNamesAndProperties(team: Team, event: string, properties: Properties): Promise<void> {
-        const timeout = timeoutGuard('Still running "storeNamesAndProperties". Timeout warning after 30 sec!', {
-            event: event,
-            ingested: team.ingested_event,
-        })
-        // In _capture we only prefetch a couple of fields in Team to avoid fetching too much data
-        let save = false
-        if (!team.ingested_event) {
-            // First event for the team captured
-            const organizationMembers = await this.db.postgresQuery(
-                'SELECT distinct_id FROM posthog_user JOIN posthog_organizationmembership ON posthog_user.id = posthog_organizationmembership.user_id WHERE organization_id = $1',
-                [team.organization_id],
-                'posthog_organizationmembership'
-            )
-            const distinctIds: { distinct_id: string }[] = organizationMembers.rows
-            for (const { distinct_id } of distinctIds) {
-                this.posthog.identify(distinct_id)
-                this.posthog.capture('first team event ingested', { team: team.uuid })
-            }
-            team.ingested_event = true
-            save = true
-        }
-        if (team.event_names && !team.event_names.includes(event)) {
-            save = true
-            team.event_names.push(event)
-            team.event_names_with_usage.push({ event: event, usage_count: null, volume: null })
-        }
-        for (const [key, value] of Object.entries(properties)) {
-            if (team.event_properties && !team.event_properties.includes(key)) {
-                team.event_properties.push(key)
-                team.event_properties_with_usage.push({ key: key, usage_count: null, volume: null })
-                save = true
-            }
-            if (
-                typeof value === 'number' &&
-                team.event_properties_numerical &&
-                !team.event_properties_numerical.includes(key)
-            ) {
-                team.event_properties_numerical.push(key)
-                save = true
-            }
-        }
-        if (save) {
-            const timeout2 = timeoutGuard(
-                'Still running "storeNamesAndProperties" save. Timeout warning after 30 sec!',
-                { event }
-            )
-            await this.db.postgresQuery(
-                `UPDATE posthog_team SET
-                    ingested_event = $1, event_names = $2, event_names_with_usage = $3, event_properties = $4,
-                    event_properties_with_usage = $5, event_properties_numerical = $6
-                WHERE id = $7`,
-                [
-                    team.ingested_event,
-                    JSON.stringify(team.event_names),
-                    JSON.stringify(team.event_names_with_usage),
-                    JSON.stringify(team.event_properties),
-                    JSON.stringify(team.event_properties_with_usage),
-                    JSON.stringify(team.event_properties_numerical),
-                    team.id,
-                ],
-                'storeNamesAndProperties'
-            )
-            clearTimeout(timeout2)
-        }
-        clearTimeout(timeout)
     }
 
     private async createEvent(

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -6,7 +6,6 @@ import { Producer } from 'kafkajs'
 import { DateTime, Duration } from 'luxon'
 import * as fetch from 'node-fetch'
 import { nodePostHog } from 'posthog-js-lite/dist/src/targets/node'
-import { TeamManager } from 'worker/ingestion/team-manager'
 
 import { Event as EventProto, IEvent } from '../../idl/protos'
 import Client from '../../shared/celery/client'
@@ -31,6 +30,7 @@ import {
     Team,
     TimestampFormat,
 } from '../../types'
+import { TeamManager } from './team-manager'
 
 export class EventsProcessor {
     pluginsServer: PluginsServer

--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -5,6 +5,8 @@ import { DB } from '../../shared/db'
 import { timeoutGuard } from '../../shared/ingestion/utils'
 import { Team, TeamId } from '../../types'
 
+type TeamWithEventUuid = Team & { __fetch_event_uuid?: string }
+
 export class TeamManager {
     db: DB
     teamCache: Map<TeamId, [Team | null, number]>
@@ -80,7 +82,7 @@ export class TeamManager {
         properties: Properties,
         posthog: ReturnType<typeof nodePostHog>
     ): Promise<void> {
-        let team = await this.fetchTeam(teamId)
+        let team: TeamWithEventUuid | null = await this.fetchTeam(teamId)
 
         if (!team) {
             return

--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -9,7 +9,7 @@ type TeamWithEventUuid = Team & { __fetch_event_uuid?: string }
 
 export class TeamManager {
     db: DB
-    teamCache: Map<TeamId, [Team | null, number]>
+    teamCache: Map<TeamId, [TeamWithEventUuid | null, number]>
     shouldSendWebhooksCache: Map<TeamId, [boolean, number]>
 
     constructor(db: DB) {
@@ -31,7 +31,7 @@ export class TeamManager {
                 [teamId],
                 'selectTeam'
             )
-            const team: Team | null = teamQueryResult.rows[0] || null
+            const team: TeamWithEventUuid | null = teamQueryResult.rows[0] || null
             if (team) {
                 team.__fetch_event_uuid = eventUuid
             }

--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -1,8 +1,9 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import { nodePostHog } from 'posthog-js-lite/dist/src/targets/node'
-import { DB } from 'shared/db'
-import { timeoutGuard } from 'shared/ingestion/utils'
-import { Team, TeamId } from 'types'
+
+import { DB } from '../../shared/db'
+import { timeoutGuard } from '../../shared/ingestion/utils'
+import { Team, TeamId } from '../../types'
 
 export class TeamManager {
     db: DB

--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -1,0 +1,79 @@
+import { DB } from 'shared/db'
+import { timeoutGuard } from 'shared/ingestion/utils'
+import { Team, TeamId } from 'types'
+
+export class TeamManager {
+    db: DB
+    teamCache: Map<TeamId, [Team | null, Date]>
+    shouldSendWebhooksCache: Map<TeamId, [boolean, Date]>
+
+    constructor(db: DB) {
+        this.db = db
+        this.teamCache = new Map()
+        this.shouldSendWebhooksCache = new Map()
+    }
+
+    public async fetchTeam(teamId: number): Promise<Team | null> {
+        const cachedTeam = this.getByAge(this.teamCache, teamId)
+        if (cachedTeam) {
+            return cachedTeam
+        }
+
+        const timeout = timeoutGuard(`Still running "fetchTeam". Timeout warning after 30 sec!`)
+        try {
+            const teamQueryResult = await this.db.postgresQuery(
+                'SELECT * FROM posthog_team WHERE id = $1',
+                [teamId],
+                'selectTeam'
+            )
+            const team: Team | null = teamQueryResult.rows[0]
+
+            this.teamCache.set(teamId, [team, new Date()])
+            return team
+        } finally {
+            clearTimeout(timeout)
+        }
+    }
+
+    public async shouldSendWebhooks(teamId: number): Promise<boolean> {
+        const cachedValue = this.getByAge(this.shouldSendWebhooksCache, teamId)
+        if (cachedValue !== undefined) {
+            return cachedValue
+        }
+
+        const team = await this.fetchTeam(teamId)
+        if (!team || !team.slack_incoming_webhook) {
+            return false
+        }
+
+        const timeout = timeoutGuard(`Still running "shouldSendWebhooks". Timeout warning after 30 sec!`)
+        try {
+            const hookQueryResult = await this.db.postgresQuery(
+                `SELECT COUNT(*) FROM ee_hook WHERE team_id = $1 AND event = 'action_performed' LIMIT 1`,
+                [team.id],
+                'shouldSendHooksTask'
+            )
+            const hasHooks = parseInt(hookQueryResult.rows[0].count) > 0
+            this.shouldSendWebhooksCache.set(teamId, [hasHooks, new Date()])
+            return hasHooks
+        } catch (error) {
+            // In FOSS PostHog ee_hook does not exist. If the error is other than that, rethrow it
+            if (!String(error).includes('relation "ee_hook" does not exist')) {
+                throw error
+            }
+            return false
+        } finally {
+            clearTimeout(timeout)
+        }
+    }
+
+    private getByAge<K, V>(cache: Map<K, [V, Date]>, key: K, maxAgeMs = 30000): V | undefined {
+        if (cache.has(key)) {
+            const [value, age] = cache.get(key)!
+            if (new Date().getTime() - age.getTime() <= maxAgeMs) {
+                return value
+            }
+        }
+        return undefined
+    }
+}

--- a/tests/helpers/plugins.ts
+++ b/tests/helpers/plugins.ts
@@ -101,7 +101,7 @@ export const mockPluginWithArchive = (indexJs: string, pluginJson?: string): Plu
 })
 
 export const makePluginObjects = (
-    indexJs: string
+    indexJs = ''
 ): {
     pluginRows: Plugin[]
     pluginConfigRows: PluginConfig[]

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -237,7 +237,7 @@ export const createProcessEventTests = (
         )
 
         if (database === 'clickhouse') {
-            expect(queryCounter).toBe(11)
+            expect(queryCounter).toBe(10)
         } else if (database === 'postgresql') {
             expect(queryCounter).toBe(14)
         }

--- a/tests/worker/ingestion/team-manager.test.ts
+++ b/tests/worker/ingestion/team-manager.test.ts
@@ -1,0 +1,206 @@
+import { mocked } from 'ts-jest/utils'
+
+import { createServer } from '../../../src/shared/server'
+import { PluginsServer } from '../../../src/types'
+import { TeamManager } from '../../../src/worker/ingestion/team-manager'
+import { resetTestDatabase } from '../../helpers/sql'
+
+describe('TeamManager()', () => {
+    let server: PluginsServer
+    let closeServer: () => Promise<void>
+    let teamManager: TeamManager
+
+    beforeEach(async () => {
+        ;[server, closeServer] = await createServer()
+        await resetTestDatabase()
+        teamManager = new TeamManager(server.db)
+    })
+    afterEach(async () => {
+        await closeServer()
+    })
+
+    describe('fetchTeam()', () => {
+        it('fetches and caches the team', async () => {
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
+            jest.spyOn(server.db, 'postgresQuery')
+
+            let team = await teamManager.fetchTeam(2, 'uuid1')
+            expect(team!.name).toEqual('TEST PROJECT')
+            expect(team!.__fetch_event_uuid).toEqual('uuid1')
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:25').getTime())
+            await server.db.postgresQuery("UPDATE posthog_team SET name = 'Updated Name!'")
+
+            mocked(server.db.postgresQuery).mockClear()
+
+            team = await teamManager.fetchTeam(2, 'uuid2')
+            expect(team!.name).toEqual('TEST PROJECT')
+            expect(team!.__fetch_event_uuid).toEqual('uuid1')
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(0)
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:36').getTime())
+
+            team = await teamManager.fetchTeam(2, 'uuid3')
+            expect(team!.name).toEqual('Updated Name!')
+            expect(team!.__fetch_event_uuid).toEqual('uuid3')
+
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(1)
+        })
+
+        it('returns null when no such team', async () => {
+            expect(await teamManager.fetchTeam(-1)).toEqual(null)
+        })
+    })
+
+    describe('shouldSendWebhooks()', () => {
+        it('returns false if unknown team', async () => {
+            expect(await teamManager.shouldSendWebhooks(-1)).toEqual(false)
+        })
+
+        it('returns false if no hooks set up and team.slack_incoming_webhook == false', async () => {
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
+        })
+
+        it('returns true if hooks are set up', async () => {
+            await server.db.postgresQuery('UPDATE posthog_team SET slack_incoming_webhook = true')
+            await server.db.postgresQuery(
+                "INSERT INTO ee_hook (id, team_id, user_id, event, target, created, updated) VALUES('test_hook', 2, 1001, 'action_performed', 'http://example.com', now(), now())"
+            )
+
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(true)
+        })
+
+        it('caches results', async () => {
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
+            jest.spyOn(server.db, 'postgresQuery')
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
+
+            await server.db.postgresQuery('UPDATE posthog_team SET slack_incoming_webhook = true')
+            await server.db.postgresQuery(
+                "INSERT INTO ee_hook (id, team_id, user_id, event, target, created, updated) VALUES('test_hook', 2, 1001, 'action_performed', 'http://example.com', now(), now())"
+            )
+            mocked(server.db.postgresQuery).mockClear()
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:25').getTime())
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(0)
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:45').getTime())
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(true)
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe('updateEventNamesAndProperties()', () => {
+        let posthog: any
+
+        beforeEach(async () => {
+            posthog = { capture: jest.fn(), identify: jest.fn() }
+            await server.db.postgresQuery(
+                `
+                UPDATE posthog_team SET
+                    ingested_event = $1,
+                    event_names = $2,
+                    event_names_with_usage = $3,
+                    event_properties = $4,
+                    event_properties_with_usage = $5,
+                    event_properties_numerical = $6`,
+                [
+                    true,
+                    JSON.stringify(['$pageview']),
+                    JSON.stringify([{ event: '$pageview', usage_count: 2, volume: 3 }]),
+                    JSON.stringify(['property_name', 'numeric_prop']),
+                    JSON.stringify([
+                        { key: 'property_name', usage_count: null, volume: null },
+                        { key: 'numeric_prop', usage_count: null, volume: null },
+                    ]),
+                    JSON.stringify(['numeric_prop']),
+                ]
+            )
+        })
+
+        it('updates event properties', async () => {
+            await teamManager.updateEventNamesAndProperties(
+                2,
+                'new-event',
+                '',
+                { property_name: 'efg', number: 4, numeric_prop: 5 },
+                posthog
+            )
+            teamManager.teamCache.clear()
+
+            const team = await teamManager.fetchTeam(2)
+            expect(team?.event_names).toEqual(['$pageview', 'new-event'])
+            expect(team?.event_names_with_usage).toEqual([
+                { event: '$pageview', usage_count: 2, volume: 3 },
+                { event: 'new-event', usage_count: null, volume: null },
+            ])
+            expect(team?.event_properties).toEqual(['property_name', 'numeric_prop', 'number'])
+            expect(team?.event_properties_with_usage).toEqual([
+                { key: 'property_name', usage_count: null, volume: null },
+                { key: 'numeric_prop', usage_count: null, volume: null },
+                { key: 'number', usage_count: null, volume: null },
+            ])
+            expect(team?.event_properties_numerical).toEqual(['numeric_prop', 'number'])
+        })
+
+        it('does not update anything if nothing changes', async () => {
+            await teamManager.fetchTeam(2, 'uuid1')
+            jest.spyOn(server.db, 'postgresQuery')
+
+            await teamManager.updateEventNamesAndProperties(2, '$pageview', '', {}, posthog)
+
+            expect(server.db.postgresQuery).not.toHaveBeenCalled()
+        })
+
+        it('does not capture event', async () => {
+            await teamManager.updateEventNamesAndProperties(
+                2,
+                'new-event',
+                '',
+                { property_name: 'efg', number: 4 },
+                posthog
+            )
+
+            expect(posthog.identify).not.toHaveBeenCalled()
+            expect(posthog.capture).not.toHaveBeenCalled()
+        })
+
+        it('handles cache invalidation properly', async () => {
+            await teamManager.fetchTeam(2, 'uuid1')
+            await server.db.postgresQuery('UPDATE posthog_team SET event_names = $1', [
+                JSON.stringify(['$pageview', '$foobar']),
+            ])
+
+            jest.spyOn(teamManager, 'fetchTeam')
+            jest.spyOn(server.db, 'postgresQuery')
+
+            // Scenario: Different request comes in, team gets reloaded in the background with no updates
+            await teamManager.updateEventNamesAndProperties(2, '$foobar', 'uuid2', {}, posthog)
+            expect(teamManager.fetchTeam).toHaveBeenCalledTimes(2)
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(1)
+
+            // Scenario: Next request but a real update
+            mocked(teamManager.fetchTeam).mockClear()
+            mocked(server.db.postgresQuery).mockClear()
+
+            await teamManager.updateEventNamesAndProperties(2, '$newevent', 'uuid2', {}, posthog)
+            expect(teamManager.fetchTeam).toHaveBeenCalledTimes(1)
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(1)
+        })
+
+        describe('first event has not yet been ingested', () => {
+            beforeEach(async () => {
+                await server.db.postgresQuery('UPDATE posthog_team SET ingested_event = false')
+            })
+
+            it('calls posthog.identify and posthog.capture', async () => {
+                await teamManager.updateEventNamesAndProperties(2, 'new-event', '', {}, posthog)
+
+                const team = await teamManager.fetchTeam(2, 'uuid1')
+                expect(posthog.identify).toHaveBeenCalledWith('plugin_test_user_distinct_id_1001')
+                expect(posthog.capture).toHaveBeenCalledWith('first team event ingested', { team: team!.uuid })
+            })
+        })
+    })
+})


### PR DESCRIPTION
After this we cache Team objects in memory. Solves https://github.com/PostHog/plugin-server/issues/257 and speeds up ingestion by reducing the amount of time spent on the top 2 queries.

Future work: 
- Make the schema sane. We're using an array-inside-jsonb which cannot be updated idempotently unless we add pl/pgsql functions to help us. Note that this updating is also (already) racy as well.
- Maybe move this out to main thread or use bloom filters if memory becomes a problem.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
