### PR TITLE
Clean up extensions approach

### DIFF
--- a/src/worker/vm/extensions/google.ts
+++ b/src/worker/vm/extensions/google.ts
@@ -1,10 +1,10 @@
 import * as BigQuery from '@google-cloud/bigquery'
 
-type DummyCloud = {
+export interface DummyCloud {
     bigquery: typeof BigQuery
 }
 
-type DummyGoogle = {
+export interface DummyGoogle {
     cloud: DummyCloud
 }
 

--- a/src/worker/vm/extensions/index.ts
+++ b/src/worker/vm/extensions/index.ts
@@ -1,0 +1,29 @@
+import { CacheExtension, ConsoleExtension, StorageExtension } from '@posthog/plugin-scaffold'
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch'
+
+import { PluginConfig, PluginsServer } from '../../../types'
+import { createCache } from './cache'
+import { createConsole } from './console'
+import { createGoogle, DummyGoogle } from './google'
+import { createPosthog, DummyPostHog } from './posthog'
+import { createStorage } from './storage'
+
+export interface Extensions {
+    fetch: (url: RequestInfo, init?: RequestInit) => Promise<Response>
+    cache: CacheExtension
+    console: ConsoleExtension
+    google: DummyGoogle
+    posthog: DummyPostHog
+    storage: StorageExtension
+}
+
+export function createExtensions(server: PluginsServer, pluginConfig: PluginConfig): Extensions {
+    return {
+        fetch: async (url, init) => await fetch(url, init),
+        cache: createCache(server, pluginConfig.plugin_id, pluginConfig.team_id),
+        console: createConsole(),
+        google: createGoogle(),
+        posthog: createPosthog(server, pluginConfig),
+        storage: createStorage(server, pluginConfig),
+    }
+}

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -118,7 +118,11 @@ test('plugin meta has what it should have', async () => {
         'attachments',
         'cache',
         'config',
+        'console',
+        'fetch',
         'global',
+        'google',
+        'posthog',
         'storage',
     ])
     expect(returnedEvent!.properties!['attachments']).toEqual({

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -600,7 +600,7 @@ test('fetch', async () => {
     }
 
     await vm.methods.processEvent(event)
-    expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched')
+    expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', undefined)
 
     expect(event.properties).toEqual({ count: 2, query: 'bla', results: [true, true] })
 })


### PR DESCRIPTION
## Changes

Stemming from https://github.com/PostHog/plugin-server/pull/247#issuecomment-804865717, this is a way to make extensions more usable.
Currently some of them are part of plugin meta, while others are globals. And the latter half is not usable in TypeScript plugins: it requires plugin developers to write their own definition of the extension and to convince TypeScript that the global will surely be injected at runtime. With the meta object on the other hand it's just a matter of using `PluginMeta` from the plugin scaffold and everything works.
This PR injects everything into both globals and meta, with a unified `createExtensions` in `extensions/index`, which allows the plugin server (VM generation in particular) to be agnostic of particular extensions.

## Checklist

-   [ ] Jest tests
