### PR TITLE
Kafka message batching - set batch size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | KAFKA_CLIENT_CERT_B64         | Kafka certificate in Base64                                | `null`                                |
 | KAFKA_CLIENT_CERT_KEY_B64     | Kafka certificate key in Base64                            | `null`                                |
 | KAFKA_TRUSTED_CERT_B64        | Kafka trusted CA in Base64                                 | `null`                                |
-| KAFKA_PRODUCER_MAX_QUEUE_SIZE | Kafka producer queue max size before flushing              | `20`                                  |
-| KAFKA_FLUSH_FREQUENCY_MS      | Kafka producer queue max duration before flushing          | `500`                                 |
+| KAFKA_PRODUCER_MAX_QUEUE_SIZE | Kafka producer batch max size before flushing              | `20`                                  |
+| KAFKA_FLUSH_FREQUENCY_MS      | Kafka producer batch max duration before flushing          | `500`                                 |
+| KAFKA_MAX_MESSAGE_BATCH_SIZE  | Kafka producer batch max size in bytes before flushing     | `900000`                              |
 | DISABLE_WEB                   | whether to disable web server                              | `true`                                |
 | WEB_PORT                      | port for web server to listen on                           | `3008`                                |
 | WEB_HOSTNAME                  | hostname for web server to listen on                       | `'0.0.0.0'`                           |

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -26,6 +26,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_TRUSTED_CERT_B64: null,
         KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
         KAFKA_PRODUCER_MAX_QUEUE_SIZE: isTestEnv ? 0 : 1000,
+        KAFKA_MAX_MESSAGE_BATCH_SIZE: 900_000,
         KAFKA_FLUSH_FREQUENCY_MS: 500,
         PLUGINS_CELERY_QUEUE: 'posthog-plugins',
         REDIS_URL: 'redis://127.0.0.1',

--- a/src/shared/kafka-producer-wrapper.ts
+++ b/src/shared/kafka-producer-wrapper.ts
@@ -1,0 +1,90 @@
+import { StatsD } from 'hot-shots'
+import { Producer, ProducerRecord } from 'kafkajs'
+
+import { PluginsServerConfig } from '../types'
+import { timeoutGuard } from './ingestion/utils'
+import { instrumentQuery } from './metrics'
+
+export class KafkaProducerWrapper {
+    /** Kafka producer used for syncing Postgres and ClickHouse person data. */
+    producer: Producer
+    /** StatsD instance used to do instrumentation */
+    statsd: StatsD | undefined
+
+    lastFlushTime: number
+    currentBatch: Array<ProducerRecord>
+    currentBatchSize: number
+
+    flushFrequencyMs: number
+    maxQueueSize: number
+    maxBatchSize: number
+
+    flushInterval: NodeJS.Timeout
+
+    constructor(producer: Producer, statsd: StatsD | undefined, serverConfig: PluginsServerConfig) {
+        this.producer = producer
+        this.statsd = statsd
+
+        this.lastFlushTime = Date.now()
+        this.currentBatch = []
+        this.currentBatchSize = 0
+
+        this.flushFrequencyMs = serverConfig.KAFKA_FLUSH_FREQUENCY_MS
+        this.maxQueueSize = serverConfig.KAFKA_PRODUCER_MAX_QUEUE_SIZE
+        this.maxBatchSize = serverConfig.KAFKA_MAX_MESSAGE_BATCH_SIZE
+
+        this.flushInterval = setInterval(() => this.flush(), this.flushFrequencyMs)
+    }
+
+    async queueMessage(kafkaMessage: ProducerRecord): Promise<void> {
+        const messageSize = this.getMessageSize(kafkaMessage)
+
+        if (this.currentBatchSize + messageSize > this.maxBatchSize) {
+            await this.flush(kafkaMessage)
+        } else {
+            this.currentBatch.push(kafkaMessage)
+            this.currentBatchSize += messageSize
+
+            const timeSinceLastFlush = Date.now() - this.lastFlushTime
+            if (timeSinceLastFlush > this.flushFrequencyMs || this.currentBatch.length >= this.maxQueueSize) {
+                await this.flush()
+            }
+        }
+    }
+
+    public flush(append?: ProducerRecord): Promise<void> {
+        if (this.currentBatch.length === 0) {
+            return Promise.resolve()
+        }
+
+        return instrumentQuery(this.statsd, 'query.kafka_send', undefined, async () => {
+            const messages = this.currentBatch
+            this.lastFlushTime = Date.now()
+            this.currentBatch = append ? [append] : []
+            this.currentBatchSize = append ? this.getMessageSize(append) : 0
+
+            const timeout = timeoutGuard('Kafka message sending delayed. Waiting over 30 sec to send messages.')
+            try {
+                await this.producer.sendBatch({
+                    topicMessages: messages,
+                })
+            } finally {
+                clearTimeout(timeout)
+            }
+        })
+    }
+
+    private getMessageSize(kafkaMessage: ProducerRecord): number {
+        return kafkaMessage.messages
+            .map((message) => {
+                if (message.value === null) {
+                    return 4
+                }
+                if (!Buffer.isBuffer(message.value)) {
+                    message.value = Buffer.from(message.value)
+                }
+                return message.value.length
+            })
+            .reduce((a, b) => a + b)
+    }
+}

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -1,0 +1,18 @@
+import { StatsD, Tags } from 'hot-shots'
+
+export async function instrumentQuery<T>(
+    statsd: StatsD | undefined,
+    metricName: string,
+    tag: string | undefined,
+    runQuery: () => Promise<T>
+): Promise<T> {
+    const tags: Tags | undefined = tag ? { queryTag: tag } : undefined
+    const timer = new Date()
+
+    statsd?.increment(`${metricName}.total`, tags)
+    try {
+        return await runQuery()
+    } finally {
+        statsd?.timing(metricName, timer, tags)
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,12 +3,13 @@ import { PluginAttachment, PluginConfigSchema, PluginEvent, Properties } from '@
 import { Pool as GenericPool } from 'generic-pool'
 import { StatsD } from 'hot-shots'
 import { Redis } from 'ioredis'
-import { Kafka, Producer } from 'kafkajs'
+import { Kafka } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { Pool } from 'pg'
 import { VM } from 'vm2'
 
 import { DB } from './shared/db'
+import { KafkaProducerWrapper } from './shared/kafka-producer-wrapper'
 import { EventsProcessor } from './worker/ingestion/process-event'
 import { LazyPluginVM } from './worker/vm/lazy'
 
@@ -39,6 +40,9 @@ export interface PluginsServerConfig extends Record<string, any> {
     KAFKA_CLIENT_CERT_KEY_B64: string | null
     KAFKA_TRUSTED_CERT_B64: string | null
     KAFKA_CONSUMPTION_TOPIC: string | null
+    KAFKA_PRODUCER_MAX_QUEUE_SIZE: number
+    KAFKA_MAX_MESSAGE_BATCH_SIZE: number
+    KAFKA_FLUSH_FREQUENCY_MS: number
     PLUGINS_CELERY_QUEUE: string
     REDIS_URL: string
     BASE_DIR: string
@@ -63,7 +67,7 @@ export interface PluginsServer extends PluginsServerConfig {
     redisPool: GenericPool<Redis>
     clickhouse?: ClickHouse
     kafka?: Kafka
-    kafkaProducer?: Producer
+    kafkaProducer?: KafkaProducerWrapper
     statsd?: StatsD
     // currently enabled plugin status
     plugins: Map<PluginId, Plugin>

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -2,7 +2,6 @@ import ClickHouse from '@posthog/clickhouse'
 import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import equal from 'fast-deep-equal'
-import { Producer } from 'kafkajs'
 import { DateTime, Duration } from 'luxon'
 import * as fetch from 'node-fetch'
 import { nodePostHog } from 'posthog-js-lite/dist/src/targets/node'
@@ -17,6 +16,7 @@ import {
     sanitizeEventName,
     timeoutGuard,
 } from '../../shared/ingestion/utils'
+import { KafkaProducerWrapper } from '../../shared/kafka-producer-wrapper'
 import { status } from '../../shared/status'
 import { castTimestampOrNow, UUID, UUIDT } from '../../shared/utils'
 import {
@@ -35,8 +35,8 @@ import { TeamManager } from './team-manager'
 export class EventsProcessor {
     pluginsServer: PluginsServer
     db: DB
-    clickhouse: ClickHouse
-    kafkaProducer: Producer
+    clickhouse: ClickHouse | undefined
+    kafkaProducer: KafkaProducerWrapper | undefined
     celery: Client
     posthog: ReturnType<typeof nodePostHog>
     teamManager: TeamManager
@@ -44,8 +44,8 @@ export class EventsProcessor {
     constructor(pluginsServer: PluginsServer) {
         this.pluginsServer = pluginsServer
         this.db = pluginsServer.db
-        this.clickhouse = pluginsServer.clickhouse!
-        this.kafkaProducer = pluginsServer.kafkaProducer!
+        this.clickhouse = pluginsServer.clickhouse
+        this.kafkaProducer = pluginsServer.kafkaProducer
         this.celery = new Client(pluginsServer.db, pluginsServer.CELERY_DEFAULT_QUEUE)
         this.teamManager = new TeamManager(pluginsServer.db)
         this.posthog = nodePostHog('sTMFPsFhdP1Ssg', { fetch })
@@ -436,7 +436,7 @@ export class EventsProcessor {
         }
 
         if (this.kafkaProducer) {
-            await this.db.queueKafkaMessage({
+            await this.kafkaProducer.queueMessage({
                 topic: KAFKA_EVENTS,
                 messages: [
                     {
@@ -517,7 +517,7 @@ export class EventsProcessor {
         }
 
         if (this.kafkaProducer) {
-            await this.db.queueKafkaMessage({
+            await this.kafkaProducer.queueMessage({
                 topic: KAFKA_SESSION_RECORDING_EVENTS,
                 messages: [{ key: uuid, value: Buffer.from(JSON.stringify(data)) }],
             })

--- a/src/worker/vm/extensions/posthog.ts
+++ b/src/worker/vm/extensions/posthog.ts
@@ -32,7 +32,7 @@ export function createPosthog(server: PluginsServer, pluginConfig: PluginConfig)
                 throw new Error('kafkaProducer not configured!')
             }
             // ignore the promise, run in the background just like with celery
-            void server.db.queueKafkaMessage({
+            void server.kafkaProducer.queueMessage({
                 topic: server.KAFKA_CONSUMPTION_TOPIC!,
                 messages: [
                     {

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -62,7 +62,7 @@ export const createTaskRunner = (server: PluginsServer): TaskWorker => async ({ 
         await loadSchedule(server)
     }
     if (task === 'flushKafkaMessages') {
-        await server.db.flushKafkaMessages()
+        await server.kafkaProducer?.flush()
     }
     server.statsd?.timing(`piscina_task.${task}`, timer)
     return response

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -53,7 +53,7 @@ describe('e2e clickhouse ingestion', () => {
         expect((await server.db.fetchEvents()).length).toBe(0)
         const uuid = new UUIDT().toString()
         posthog.capture('custom event', { name: 'haha', uuid })
-        await server.db.flushKafkaMessages()
+        await server.kafkaProducer?.flush()
         await delayUntilEventIngested(() => server.db.fetchEvents())
         const events = await server.db.fetchEvents()
         expect(events.length).toBe(1)

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -302,10 +302,10 @@ describe('createTaskRunner()', () => {
     })
 
     it('handles `flushKafkaMessages` task', async () => {
-        server.db = { flushKafkaMessages: jest.fn() }
+        server.kafkaProducer = { flush: jest.fn() }
 
         await taskRunner({ task: 'flushKafkaMessages' })
 
-        expect(server.db.flushKafkaMessages).toHaveBeenCalled()
+        expect(server.kafkaProducer.flush).toHaveBeenCalled()
     })
 })

--- a/tests/shared/kafka-producer-wrapper.test.ts
+++ b/tests/shared/kafka-producer-wrapper.test.ts
@@ -1,0 +1,143 @@
+import { Producer } from 'kafkajs'
+
+import { KafkaProducerWrapper } from '../../src/shared/kafka-producer-wrapper'
+import { PluginsServerConfig } from '../../src/types'
+
+describe('KafkaProducerWrapper', () => {
+    let producer: KafkaProducerWrapper
+    let mockKafkaProducer: Producer
+    let flushSpy: any
+
+    beforeEach(() => {
+        jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
+
+        mockKafkaProducer = { sendBatch: jest.fn() } as any
+        producer = new KafkaProducerWrapper(mockKafkaProducer, undefined, {
+            KAFKA_FLUSH_FREQUENCY_MS: 20000,
+            KAFKA_PRODUCER_MAX_QUEUE_SIZE: 4,
+            KAFKA_MAX_MESSAGE_BATCH_SIZE: 500,
+        } as PluginsServerConfig)
+        clearInterval(producer.flushInterval)
+
+        flushSpy = jest.spyOn(producer, 'flush')
+    })
+
+    describe('queueMessage()', () => {
+        it('respects MAX_QUEUE_SIZE', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(10) }],
+            })
+            await producer.queueMessage({
+                topic: 'b',
+                messages: [{ value: Buffer.alloc(30) }],
+            })
+            await producer.queueMessage({
+                topic: 'b',
+                messages: [{ value: Buffer.alloc(30) }],
+            })
+
+            expect(flushSpy).not.toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(3)
+
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(30) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.currentBatchSize).toEqual(0)
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                topicMessages: [expect.anything(), expect.anything(), expect.anything(), expect.anything()],
+            })
+        })
+
+        it('respects KAFKA_MAX_MESSAGE_BATCH_SIZE', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(450) }],
+            })
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(40) }],
+            })
+            expect(flushSpy).not.toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(2)
+
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(40) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+
+            expect(producer.currentBatch.length).toEqual(1)
+            expect(producer.currentBatchSize).toEqual(40)
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                topicMessages: [expect.anything(), expect.anything()],
+            })
+        })
+
+        it('respects KAFKA_FLUSH_FREQUENCY_MS', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(10) }],
+            })
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:20').getTime())
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(10) }],
+            })
+
+            expect(flushSpy).not.toHaveBeenCalled()
+            expect(producer.currentBatch.length).toEqual(2)
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:26').getTime())
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(10) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.lastFlushTime).toEqual(Date.now())
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                topicMessages: [expect.anything(), expect.anything(), expect.anything()],
+            })
+        })
+    })
+
+    describe('flush()', () => {
+        it('flushes messages in memory', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: Buffer.alloc(10) }],
+            })
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:15').getTime())
+
+            await producer.flush()
+
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                topicMessages: [
+                    {
+                        topic: 'a',
+                        messages: [{ value: Buffer.alloc(10) }],
+                    },
+                ],
+            })
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.currentBatchSize).toEqual(0)
+            expect(producer.lastFlushTime).toEqual(Date.now())
+        })
+
+        it('does nothing if nothing queued', async () => {
+            await producer.flush()
+
+            expect(mockKafkaProducer.sendBatch).not.toHaveBeenCalled()
+        })
+    })
+})


### PR DESCRIPTION
- Refactor instrumenting queries
- Check message sizes for flushing

This implements max batch size logic, solving https://github.com/PostHog/plugin-server/issues/263.

The implementation is sort of lazy - we could read the max size from the broker but computing a _very_ accurate message size limit felt outside the scope a bit.

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
-   [x] Jest tests
