### PR TITLE
Make isNewPerson LRU cache more effective

### DIFF
--- a/src/worker/ingestion/person-manager.ts
+++ b/src/worker/ingestion/person-manager.ts
@@ -3,7 +3,7 @@ import LRU from 'lru-cache'
 import { DB } from '../../shared/db'
 import { PluginsServerConfig } from '../../types'
 
-const TEN_MINUTES = 10 * 60 * 1000
+const ONE_HOUR = 60 * 60 * 1000
 
 export class PersonManager {
     personSeen: LRU<string, boolean>
@@ -11,7 +11,7 @@ export class PersonManager {
     constructor(serverConfig: PluginsServerConfig) {
         this.personSeen = new LRU({
             max: serverConfig.DISTINCT_ID_LRU_SIZE,
-            maxAge: TEN_MINUTES,
+            maxAge: ONE_HOUR,
             updateAgeOnGet: true,
         })
     }

--- a/src/worker/ingestion/person-manager.ts
+++ b/src/worker/ingestion/person-manager.ts
@@ -18,7 +18,7 @@ export class PersonManager {
 
     async isNewPerson(db: DB, teamId: number, distinctId: string): Promise<boolean> {
         const key = `${teamId}::${distinctId}`
-        if (this.personSeen.has(key)) {
+        if (this.personSeen.get(key)) {
             return false
         }
 


### PR DESCRIPTION
- Make isNewPerson caching more effective

    .has did not update LRU cache timestamps/LRU property, .get does. This
    means that for a frequent user the LRU entry got evicted quite fast

- Increase maxAge


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
