### PR TITLE
Fix shouldSendWebhooks conditions

### DIFF
--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -5,12 +5,15 @@ import { DB } from '../../shared/db'
 import { timeoutGuard } from '../../shared/ingestion/utils'
 import { Team, TeamId } from '../../types'
 
-type TeamWithEventUuid = Team & { __fetch_event_uuid?: string }
+interface TeamWithEventUuid extends Team {
+    __fetch_event_uuid?: string
+}
+type TeamCache<T> = Map<TeamId, [T, number]>
 
 export class TeamManager {
     db: DB
-    teamCache: Map<TeamId, [TeamWithEventUuid | null, number]>
-    shouldSendWebhooksCache: Map<TeamId, [boolean, number]>
+    teamCache: TeamCache<TeamWithEventUuid | null>
+    shouldSendWebhooksCache: TeamCache<boolean>
 
     constructor(db: DB) {
         this.db = db
@@ -44,7 +47,7 @@ export class TeamManager {
     }
 
     public async shouldSendWebhooks(teamId: number): Promise<boolean> {
-        const cachedValue = this.getByAge(this.shouldSendWebhooksCache, teamId, 10_000)
+        const cachedValue = this.getByAge(this.shouldSendWebhooksCache, teamId, 15_000)
         if (cachedValue !== undefined) {
             return cachedValue
         }

--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -18,7 +18,7 @@ export class TeamManager {
         this.shouldSendWebhooksCache = new Map()
     }
 
-    public async fetchTeam(teamId: number, eventUuid?: string): Promise<Team | null> {
+    public async fetchTeam(teamId: number, eventUuid?: string): Promise<TeamWithEventUuid | null> {
         const cachedTeam = this.getByAge(this.teamCache, teamId)
         if (cachedTeam) {
             return cachedTeam

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -237,9 +237,9 @@ export const createProcessEventTests = (
         )
 
         if (database === 'clickhouse') {
-            expect(queryCounter).toBe(10)
+            expect(queryCounter).toBe(11)
         } else if (database === 'postgresql') {
-            expect(queryCounter).toBe(14)
+            expect(queryCounter).toBe(15)
         }
 
         let persons = await server.db.fetchPersons()

--- a/tests/worker/ingestion/team-manager.test.ts
+++ b/tests/worker/ingestion/team-manager.test.ts
@@ -70,18 +70,36 @@ describe('TeamManager()', () => {
             expect(await teamManager.shouldSendWebhooks(2)).toEqual(true)
         })
 
-        it('caches results', async () => {
+        it('caches results, webhooks case', async () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
             jest.spyOn(server.db, 'postgresQuery')
+
             expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
 
-            await server.db.postgresQuery('UPDATE posthog_team SET slack_incoming_webhook = true')
+            await server.db.postgresQuery("UPDATE posthog_team SET slack_incoming_webhook = 'https://x.com/'")
+            mocked(server.db.postgresQuery).mockClear()
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:10').getTime())
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(0)
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:45').getTime())
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(true)
+            expect(server.db.postgresQuery).toHaveBeenCalledTimes(1)
+        })
+
+        it('caches results, Zapier hooks-only case', async () => {
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
+            jest.spyOn(server.db, 'postgresQuery')
+
+            expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
+
             await server.db.postgresQuery(
                 "INSERT INTO ee_hook (id, team_id, user_id, event, target, created, updated) VALUES('test_hook', 2, 1001, 'action_performed', 'http://example.com', now(), now())"
             )
             mocked(server.db.postgresQuery).mockClear()
 
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:25').getTime())
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:10').getTime())
             expect(await teamManager.shouldSendWebhooks(2)).toEqual(false)
             expect(server.db.postgresQuery).toHaveBeenCalledTimes(0)
 

--- a/tests/worker/ingestion/team-manager.test.ts
+++ b/tests/worker/ingestion/team-manager.test.ts
@@ -70,7 +70,7 @@ describe('TeamManager()', () => {
             expect(await teamManager.shouldSendWebhooks(2)).toEqual(true)
         })
 
-        it('caches results, webhooks case', async () => {
+        it('caches results, webhooks-only case', async () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
             jest.spyOn(server.db, 'postgresQuery')
 


### PR DESCRIPTION
## Changes

Since #271 got merged, we've got reports from Cloud users that their webhooks stopped firing. Looks like the conditions in the reworked cached `shouldSendWebhooks` were incorrect, resulting in the method wrongly returning `false` for projects with non-empty `slack_incoming_webhook`, and only returning `true` for projects with Zapier hooks (which meant webhooks kept working for our own project).

## Checklist

-   [ ] Jest tests
