### PR TITLE
Fix for non-string distinct IDs 

### DIFF
--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -5,7 +5,7 @@ import { PluginsServer, Queue } from 'types'
 
 import { timeoutGuard } from '../../shared/ingestion/utils'
 import { status } from '../../shared/status'
-import { groupIntoBatches, killGracefully } from '../../shared/utils'
+import { groupIntoBatches, killGracefully, sanitizeEvent } from '../../shared/utils'
 
 export class KafkaQueue implements Queue {
     private pluginsServer: PluginsServer
@@ -45,11 +45,11 @@ export class KafkaQueue implements Queue {
             const event = { ...rawEvent, ...JSON.parse(dataStr) }
             uuidOrder.set(event.uuid, index)
             uuidOffset.set(event.uuid, message.offset)
-            return {
+            return sanitizeEvent({
                 ...event,
                 site_url: event.site_url || null,
                 ip: event.ip || null,
-            }
+            })
         })
 
         const maxBatchSize = Math.max(

--- a/src/main/queue.ts
+++ b/src/main/queue.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/node'
 
 import Client from '../shared/celery/client'
 import { status } from '../shared/status'
-import { UUIDT } from '../shared/utils'
+import { sanitizeEvent, UUIDT } from '../shared/utils'
 import { IngestEventResponse, PluginsServer, Queue } from '../types'
 import CeleryQueueWorker from './ingestion/celery-queue-worker'
 import { KafkaQueue } from './ingestion/kafka-queue'
@@ -66,7 +66,7 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
             now: string,
             sent_at?: string
         ) => {
-            const event = {
+            const event = sanitizeEvent({
                 distinct_id,
                 ip,
                 site_url,
@@ -75,7 +75,7 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
                 sent_at,
                 uuid: new UUIDT().toString(),
                 ...data,
-            } as PluginEvent
+            } as PluginEvent)
             try {
                 pauseQueueIfWorkerFull(celeryQueue, server, piscina)
                 const processedEvent = await workerMethods.processEvent(event)

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,3 +1,4 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import AdmZip from 'adm-zip'
 import { randomBytes } from 'crypto'
@@ -414,4 +415,9 @@ export function createPostgresPool(serverConfig: PluginsServerConfig): Pool {
     })
 
     return postgres
+}
+
+export function sanitizeEvent(event: PluginEvent): PluginEvent {
+    event.distinct_id = event.distinct_id?.toString()
+    return event
 }

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -76,6 +76,9 @@ export class EventsProcessor {
             event: JSON.stringify(data),
         })
 
+        // sanitize values, even though `sanitizeEvent` should have gotten to them
+        distinctId = distinctId?.toString()
+
         const properties: Properties = data.properties ?? {}
         if (data['$set']) {
             properties['$set'] = data['$set']

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -128,6 +128,7 @@ export async function createUserTeamAndOrganization(
         api_token: `THIS IS NOT A TOKEN FOR TEAM ${teamId}`,
         test_account_filters: [],
         timezone: 'UTC',
+        data_attributes: JSON.stringify(['data-attr']),
     })
 }
 

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -1392,5 +1392,24 @@ export const createProcessEventTests = (
         expect(person2.properties).toEqual({ a_prop: 'test-1', b_prop: 'test-2b', c_prop: 'test-1' })
     })
 
+    test('distinct_id wrong type (number)', async () => {
+        await createPerson(server, team, ['asdfasdfasdf'])
+        await processEvent(
+            (12345 as unknown) as string,
+            null,
+            '',
+            ({
+                event: '$pageview',
+                properties: { distinct_id: 'asdfasdfasdf', token: team.api_token },
+            } as any) as PluginEvent,
+            team.id,
+            now,
+            now,
+            new UUIDT().toString()
+        )
+        const [event] = await server.db.fetchEvents()
+        expect(event.distinct_id).toEqual('12345')
+    })
+
     return returned
 }


### PR DESCRIPTION
## Changes

- These should have been sanitized in the API before reaching the plugin server over Kafka, but let's clear it up anyway.
- Resolves issue for a customer who was using a RudderStack connector to get events into PostHog and had IDs as numbers.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
