### PR TITLE
Shutdown tests

### DIFF
--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -77,9 +77,8 @@ test('piscina worker test', async () => {
     const ingestResponse2 = await ingestEvent({ ...createEvent(), uuid: new UUIDT().toString() })
     expect(ingestResponse2).toEqual({ success: true })
 
-    try {
-        await piscina.destroy()
-    } catch {}
+    console.log(piscina)
+    await piscina.destroy()
 })
 
 test('assume that the workerThreads and tasksPerWorker values behave as expected', async () => {

--- a/tests/schedule.test.ts
+++ b/tests/schedule.test.ts
@@ -125,6 +125,7 @@ describe('startSchedule', () => {
     afterEach(async () => {
         await redis.del(LOCKED_RESOURCE)
         await server.redisPool.release(redis)
+        console.log(piscina)
         await piscina.destroy()
         await closeServer()
     })


### PR DESCRIPTION
## Changes

Trying to add some logging to tests to catch this flakiness:
![image](https://user-images.githubusercontent.com/53387/113728123-11d19080-96f6-11eb-8acd-7a6008dd3ef9.png)

I think that error comes up when [some piscina task is still running while we try to close piscina](https://github.com/PostHog/piscina/blob/47505dfda4985e677b01e68409d5012dc49cba9c/test/abort-task.ts#L144). But what could still be running...? Console.log to the rescue!

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
