### PR TITLE
Attempt making Kafka batching more efficient

### DIFF
--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -206,6 +206,8 @@ export class KafkaQueue implements Queue {
             groupId: 'clickhouse-ingestion',
             sessionTimeout: 60000,
             readUncommitted: false,
+            minBytes: 16_384,
+            maxWaitTimeInMs: 500,
         })
         const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
         consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {


### PR DESCRIPTION
## Changes

This will result in batches of Kafka messages being processed once the batch is at least 16 kB or 500 ms since the last once - whichever earlier. Should increase batch sizes on Cloud from 1-2 messages per batch, making processing more efficient.

