### PR TITLE
Redis password has its own env

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -376,7 +376,7 @@ export async function tryTwice<T extends any>(
 export async function createRedis(serverConfig: PluginsServerConfig): Promise<Redis.Redis> {
     const credentials: Partial<RedisOptions> | undefined = serverConfig.POSTHOG_REDIS_HOST
         ? {
-              password: serverConfig.POSTHOG_DB_PASSWORD,
+              password: serverConfig.POSTHOG_REDIS_PASSWORD,
               port: serverConfig.POSTHOG_REDIS_PORT,
           }
         : undefined


### PR DESCRIPTION
## Changes

🤦 

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
