### PR TITLE
Add `generic-pool`

### DIFF
--- a/src/worker/vm/imports.ts
+++ b/src/worker/vm/imports.ts
@@ -2,11 +2,13 @@ import { BigQuery } from '@google-cloud/bigquery'
 import * as contrib from '@posthog/plugin-contrib'
 import * as AWS from 'aws-sdk'
 import crypto from 'crypto'
+import * as genericPool from 'generic-pool'
 import fetch from 'node-fetch'
 import snowflake from 'snowflake-sdk'
 
 export const imports = {
     crypto: crypto,
+    'generic-pool': genericPool,
     'node-fetch': fetch,
     'snowflake-sdk': snowflake,
     '@google-cloud/bigquery': { BigQuery },


### PR DESCRIPTION
## Changes

This adds `generic-pool` to the list of things plugins can use. We're already using this library for redis pooling, so exposing it makes sense. I'll need it to make the snowflake connector work properly.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
