### PR TITLE
Add NODE_MAX_HEAP_SIZE to posthog-plugin-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | DISABLE_MMDB                  | whether to disable MMDB IP location capabilities                  | `false`                               |
 | INTERNAL_MMDB_SERVER_PORT     | port of the internal server used for IP location (0 means random) | `0`                                   |
 | DISTINCT_ID_LRU_SIZE          | size of persons distinct ID LRU cache                             | `10000`                               |
+| NODE_MAX_HEAP_SIZE            | maximum Node heap size in MB (`null` means Node default)          | `null`                                |
 
 ## Releasing a new version
 

--- a/bin/posthog-plugin-server
+++ b/bin/posthog-plugin-server
@@ -1,3 +1,5 @@
-#!/usr/bin/env node
+#!/usr/bin/env bash
 
-require(__dirname + '/../dist/index.js')
+[[ -n "$NODE_MAX_HEAP_SIZE" ]] && export NODE_OPTIONS="--max-old-space-size=$NODE_MAX_HEAP_SIZE"
+
+node "$(dirname $0)/../dist/index.js"


### PR DESCRIPTION
## Changes

This allows increasing max Node heap size beyond default.

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
