### PR TITLE
Revert "Add NODE_MAX_HEAP_SIZE to posthog-plugin-server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | DISABLE_MMDB                  | whether to disable MMDB IP location capabilities                  | `false`                               |
 | INTERNAL_MMDB_SERVER_PORT     | port of the internal server used for IP location (0 means random) | `0`                                   |
 | DISTINCT_ID_LRU_SIZE          | size of persons distinct ID LRU cache                             | `10000`                               |
-| NODE_MAX_HEAP_SIZE            | maximum Node heap size in MB (`null` means Node default)          | `null`                                |
 
 ## Releasing a new version
 

--- a/bin/posthog-plugin-server
+++ b/bin/posthog-plugin-server
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
 
-[[ -n "$NODE_MAX_HEAP_SIZE" ]] && export NODE_OPTIONS="--max-old-space-size=$NODE_MAX_HEAP_SIZE"
-
-node "$(dirname $0)/../dist/index.js"
+require(__dirname + '/../dist/index.js')


### PR DESCRIPTION
Reverts PostHog/plugin-server#319. The new start script doesn't work from `node_modules/.bin/`.