### PR TITLE
Register system events and errors with plugin logs

### DIFF
--- a/src/main/services/schedule.ts
+++ b/src/main/services/schedule.ts
@@ -163,7 +163,8 @@ export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskN
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
             .catch(async (error) => {
-                await processError(server, pluginConfigId, error)
+                const pluginConfig = await server.db.fetchPluginConfig(pluginConfigId)
+                await processError(server, pluginConfig, error)
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
     }

--- a/src/main/services/schedule.ts
+++ b/src/main/services/schedule.ts
@@ -163,8 +163,7 @@ export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskN
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
             .catch(async (error) => {
-                const pluginConfig = await server.db.fetchPluginConfig(pluginConfigId)
-                await processError(server, pluginConfig, error)
+                await processError(server, server.pluginConfigs.get(pluginConfigId) || null, error)
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
     }

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -20,6 +20,7 @@ import {
     PersonDistinctId,
     PluginConfig,
     PluginLogEntry,
+    PluginLogEntrySource,
     PluginLogEntryType,
     PostgresSessionRecordingEvent,
     RawOrganization,
@@ -597,8 +598,8 @@ export class DB {
 
     public async createPluginLogEntry(
         pluginConfig: PluginConfig,
+        source: PluginLogEntrySource,
         type: PluginLogEntryType,
-        isSystem: boolean,
         message: string,
         instanceId: UUID,
         timestamp: string = new Date().toISOString()
@@ -609,8 +610,8 @@ export class DB {
             plugin_id: pluginConfig.plugin_id,
             plugin_config_id: pluginConfig.id,
             timestamp: timestamp.replace('T', ' ').replace('Z', ''),
+            source,
             type,
-            is_system: isSystem,
             message,
             instance_id: instanceId.toString(),
         }
@@ -623,7 +624,7 @@ export class DB {
                 })
             } else {
                 await this.postgresQuery(
-                    'INSERT INTO posthog_pluginlogentry (id, team_id, plugin_id, plugin_config_id, timestamp, type, is_system, message, instance_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
+                    'INSERT INTO posthog_pluginlogentry (id, team_id, plugin_id, plugin_config_id, timestamp, source,type, message, instance_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
                     Object.values(entry),
                     'insertPluginLogEntry'
                 )

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -21,7 +21,6 @@ import {
     PluginConfig,
     PluginLogEntry,
     PluginLogEntryType,
-    PluginsServerConfig,
     PostgresSessionRecordingEvent,
     RawOrganization,
     RawPerson,
@@ -601,14 +600,15 @@ export class DB {
         type: PluginLogEntryType,
         isSystem: boolean,
         message: string,
-        instanceId: UUID
+        instanceId: UUID,
+        timestamp?: string
     ): Promise<PluginLogEntry> {
         const entry: PluginLogEntry = {
             id: new UUIDT().toString(),
             team_id: pluginConfig.team_id,
             plugin_id: pluginConfig.plugin_id,
             plugin_config_id: pluginConfig.id,
-            timestamp: new Date().toISOString().replace('T', ' ').replace('Z', ''),
+            timestamp: (timestamp ?? new Date().toISOString()).replace('T', ' ').replace('Z', ''),
             type,
             is_system: isSystem,
             message,
@@ -634,5 +634,11 @@ export class DB {
         }
 
         return entry
+    }
+
+    // PluginConfig
+
+    public async fetchPluginConfig(id: number): Promise<PluginConfig | null> {
+        return (await this.postgresQuery('SELECT * FROM posthog_pluginconfig WHERE id = $1', [id])).rows[0] ?? null
     }
 }

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -599,6 +599,7 @@ export class DB {
     public async createPluginLogEntry(
         pluginConfig: PluginConfig,
         type: PluginLogEntryType,
+        isSystem: boolean,
         message: string,
         instanceId: UUID
     ): Promise<PluginLogEntry> {
@@ -609,6 +610,7 @@ export class DB {
             plugin_config_id: pluginConfig.id,
             timestamp: new Date().toISOString().replace('T', ' ').replace('Z', ''),
             type,
+            is_system: isSystem,
             message,
             instance_id: instanceId.toString(),
         }
@@ -621,7 +623,7 @@ export class DB {
                 })
             } else {
                 await this.postgresQuery(
-                    'INSERT INTO posthog_pluginlogentry (id, team_id, plugin_id, plugin_config_id, timestamp, type, message, instance_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)',
+                    'INSERT INTO posthog_pluginlogentry (id, team_id, plugin_id, plugin_config_id, timestamp, type, is_system, message, instance_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
                     Object.values(entry),
                     'insertPluginLogEntry'
                 )

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -601,14 +601,14 @@ export class DB {
         isSystem: boolean,
         message: string,
         instanceId: UUID,
-        timestamp?: string
+        timestamp: string = new Date().toISOString()
     ): Promise<PluginLogEntry> {
         const entry: PluginLogEntry = {
             id: new UUIDT().toString(),
             team_id: pluginConfig.team_id,
             plugin_id: pluginConfig.plugin_id,
             plugin_config_id: pluginConfig.id,
-            timestamp: (timestamp ?? new Date().toISOString()).replace('T', ' ').replace('Z', ''),
+            timestamp: timestamp.replace('T', ' ').replace('Z', ''),
             type,
             is_system: isSystem,
             message,

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -635,10 +635,4 @@ export class DB {
 
         return entry
     }
-
-    // PluginConfig
-
-    public async fetchPluginConfig(id: number): Promise<PluginConfig | null> {
-        return (await this.postgresQuery('SELECT * FROM posthog_pluginconfig WHERE id = $1', [id])).rows[0] ?? null
-    }
 }

--- a/src/shared/error.ts
+++ b/src/shared/error.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { captureException } from '@sentry/minimal'
 
-import { PluginConfig, PluginConfigId, PluginError, PluginsServer } from '../types'
+import { PluginConfig, PluginError, PluginsServer } from '../types'
 import { setError } from './sql'
 
 export async function processError(

--- a/src/shared/error.ts
+++ b/src/shared/error.ts
@@ -1,14 +1,19 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { captureException } from '@sentry/minimal'
 
 import { PluginConfig, PluginConfigId, PluginError, PluginsServer } from '../types'
 import { setError } from './sql'
 
 export async function processError(
     server: PluginsServer,
-    pluginConfig: PluginConfig | PluginConfigId,
+    pluginConfig: PluginConfig | null,
     error: Error | string,
     event?: PluginEvent | null
 ): Promise<void> {
+    if (!pluginConfig) {
+        captureException(new Error('Tried to process error for nonexistent plugin config!'))
+        return
+    }
     const errorJson: PluginError =
         typeof error === 'string'
             ? {
@@ -26,6 +31,6 @@ export async function processError(
     await setError(server, errorJson, pluginConfig)
 }
 
-export async function clearError(server: PluginsServer, pluginConfig: PluginConfig | PluginConfigId): Promise<void> {
+export async function clearError(server: PluginsServer, pluginConfig: PluginConfig): Promise<void> {
     await setError(server, null, pluginConfig)
 }

--- a/src/shared/sql.ts
+++ b/src/shared/sql.ts
@@ -1,4 +1,12 @@
-import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginLogEntryType, PluginsServer } from '../types'
+import {
+    Plugin,
+    PluginAttachmentDB,
+    PluginConfig,
+    PluginError,
+    PluginLogEntrySource,
+    PluginLogEntryType,
+    PluginsServer,
+} from '../types'
 
 function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
     return `SELECT posthog_pluginconfig.${specificField || '*'}
@@ -45,8 +53,8 @@ export async function setError(
     if (pluginError && server.ENABLE_PERSISTENT_CONSOLE) {
         await server.db.createPluginLogEntry(
             pluginConfig,
+            PluginLogEntrySource.Plugin,
             PluginLogEntryType.Error,
-            true,
             pluginError.message,
             server.instanceId,
             pluginError.time

--- a/src/shared/sql.ts
+++ b/src/shared/sql.ts
@@ -42,7 +42,7 @@ export async function setError(
         pluginError,
         typeof pluginConfig === 'object' ? pluginConfig?.id : pluginConfig,
     ])
-    if (pluginError) {
+    if (pluginError && server.ENABLE_PERSISTENT_CONSOLE) {
         await server.db.createPluginLogEntry(
             pluginConfig,
             PluginLogEntryType.Error,

--- a/src/shared/sql.ts
+++ b/src/shared/sql.ts
@@ -1,12 +1,4 @@
-import {
-    Plugin,
-    PluginAttachmentDB,
-    PluginConfig,
-    PluginConfigId,
-    PluginError,
-    PluginLogEntryType,
-    PluginsServer,
-} from '../types'
+import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginLogEntryType, PluginsServer } from '../types'
 
 function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
     return `SELECT posthog_pluginconfig.${specificField || '*'}

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,12 @@ export interface PluginAttachmentDB {
     contents: Buffer | null
 }
 
+export enum PluginLogEntrySource {
+    System = 'SYSTEM',
+    Plugin = 'PLUGIN',
+    Console = 'CONSOLE',
+}
+
 export enum PluginLogEntryType {
     Debug = 'DEBUG',
     Log = 'LOG',
@@ -190,8 +196,8 @@ export interface PluginLogEntry {
     plugin_id: number
     plugin_config_id: number
     timestamp: string
+    source: PluginLogEntrySource
     type: PluginLogEntryType
-    is_system: boolean
     message: string
     instance_id: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,6 +191,7 @@ export interface PluginLogEntry {
     plugin_config_id: number
     timestamp: string
     type: PluginLogEntryType
+    is_system: boolean
     message: string
     instance_id: string
 }

--- a/src/worker/plugins/run.ts
+++ b/src/worker/plugins/run.ts
@@ -75,12 +75,12 @@ export async function runPluginsOnBatch(server: PluginsServer, batch: PluginEven
 export async function runPluginTask(server: PluginsServer, taskName: string, pluginConfigId: number): Promise<any> {
     const timer = new Date()
     let response
+    const pluginConfig = server.pluginConfigs.get(pluginConfigId)
     try {
-        const pluginConfig = server.pluginConfigs.get(pluginConfigId)
         const task = await pluginConfig?.vm?.getTask(taskName)
         response = await task?.exec()
     } catch (error) {
-        await processError(server, pluginConfigId, error)
+        await processError(server, pluginConfig ?? (await server.db.fetchPluginConfig(pluginConfigId)), error)
         server.statsd?.increment(`plugin.task.${taskName}.${pluginConfigId}.ERROR`)
     }
     server.statsd?.timing(`plugin.task.${taskName}.${pluginConfigId}`, timer)

--- a/src/worker/plugins/run.ts
+++ b/src/worker/plugins/run.ts
@@ -80,7 +80,7 @@ export async function runPluginTask(server: PluginsServer, taskName: string, plu
         const task = await pluginConfig?.vm?.getTask(taskName)
         response = await task?.exec()
     } catch (error) {
-        await processError(server, pluginConfig ?? (await server.db.fetchPluginConfig(pluginConfigId)), error)
+        await processError(server, pluginConfig || null, error)
         server.statsd?.increment(`plugin.task.${taskName}.${pluginConfigId}.ERROR`)
     }
     server.statsd?.timing(`plugin.task.${taskName}.${pluginConfigId}`, timer)

--- a/src/worker/plugins/setup.ts
+++ b/src/worker/plugins/setup.ts
@@ -2,7 +2,7 @@ import { PluginAttachment } from '@posthog/plugin-scaffold'
 
 import { getPluginAttachmentRows, getPluginConfigRows, getPluginRows } from '../../shared/sql'
 import { status } from '../../shared/status'
-import { Plugin, PluginConfig, PluginConfigId, PluginId, PluginLogEntryType, PluginsServer, TeamId } from '../../types'
+import { Plugin, PluginConfig, PluginConfigId, PluginId, PluginsServer, TeamId } from '../../types'
 import { LazyPluginVM } from '../vm/lazy'
 import { loadPlugin } from './loadPlugin'
 import { teardownPlugins } from './teardown'

--- a/src/worker/plugins/setup.ts
+++ b/src/worker/plugins/setup.ts
@@ -2,7 +2,7 @@ import { PluginAttachment } from '@posthog/plugin-scaffold'
 
 import { getPluginAttachmentRows, getPluginConfigRows, getPluginRows } from '../../shared/sql'
 import { status } from '../../shared/status'
-import { Plugin, PluginConfig, PluginConfigId, PluginId, PluginsServer, TeamId } from '../../types'
+import { Plugin, PluginConfig, PluginConfigId, PluginId, PluginLogEntryType, PluginsServer, TeamId } from '../../types'
 import { LazyPluginVM } from '../vm/lazy'
 import { loadPlugin } from './loadPlugin'
 import { teardownPlugins } from './teardown'

--- a/src/worker/plugins/teardown.ts
+++ b/src/worker/plugins/teardown.ts
@@ -13,6 +13,10 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
                     (async () => {
                         try {
                             await teardownPlugin()
+
+                            if (!server.ENABLE_PERSISTENT_CONSOLE) {
+                                return
+                            }
                             await server.db.createPluginLogEntry(
                                 pluginConfig,
                                 PluginLogEntryType.Info,
@@ -22,6 +26,10 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
                             )
                         } catch (error) {
                             await processError(server, pluginConfig, error)
+
+                            if (!server.ENABLE_PERSISTENT_CONSOLE) {
+                                return
+                            }
                             await server.db.createPluginLogEntry(
                                 pluginConfig,
                                 PluginLogEntryType.Error,
@@ -32,7 +40,7 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
                         }
                     })()
                 )
-            } else {
+            } else if (server.ENABLE_PERSISTENT_CONSOLE) {
                 await server.db.createPluginLogEntry(
                     pluginConfig,
                     PluginLogEntryType.Info,

--- a/src/worker/plugins/teardown.ts
+++ b/src/worker/plugins/teardown.ts
@@ -14,29 +14,27 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
                         try {
                             await teardownPlugin()
 
-                            if (!server.ENABLE_PERSISTENT_CONSOLE) {
-                                return
+                            if (server.ENABLE_PERSISTENT_CONSOLE) {
+                                await server.db.createPluginLogEntry(
+                                    pluginConfig,
+                                    PluginLogEntryType.Info,
+                                    true,
+                                    `Plugin unloaded (instance ID ${server.instanceId}).`,
+                                    server.instanceId
+                                )
                             }
-                            await server.db.createPluginLogEntry(
-                                pluginConfig,
-                                PluginLogEntryType.Info,
-                                true,
-                                `Plugin unloaded (instance ID ${server.instanceId}).`,
-                                server.instanceId
-                            )
                         } catch (error) {
                             await processError(server, pluginConfig, error)
 
-                            if (!server.ENABLE_PERSISTENT_CONSOLE) {
-                                return
+                            if (server.ENABLE_PERSISTENT_CONSOLE) {
+                                await server.db.createPluginLogEntry(
+                                    pluginConfig,
+                                    PluginLogEntryType.Error,
+                                    true,
+                                    `Plugin failed to unload (instance ID ${server.instanceId}).`,
+                                    server.instanceId
+                                )
                             }
-                            await server.db.createPluginLogEntry(
-                                pluginConfig,
-                                PluginLogEntryType.Error,
-                                true,
-                                `Plugin failed to unload (instance ID ${server.instanceId}).`,
-                                server.instanceId
-                            )
                         }
                     })()
                 )

--- a/src/worker/plugins/teardown.ts
+++ b/src/worker/plugins/teardown.ts
@@ -1,5 +1,5 @@
 import { processError } from '../../shared/error'
-import { PluginConfig, PluginLogEntryType, PluginsServer } from '../../types'
+import { PluginConfig, PluginLogEntrySource, PluginLogEntryType, PluginsServer } from '../../types'
 
 export async function teardownPlugins(server: PluginsServer, pluginConfig?: PluginConfig): Promise<void> {
     const pluginConfigs = pluginConfig ? [pluginConfig] : server.pluginConfigs.values()
@@ -17,8 +17,8 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
                             if (server.ENABLE_PERSISTENT_CONSOLE) {
                                 await server.db.createPluginLogEntry(
                                     pluginConfig,
+                                    PluginLogEntrySource.System,
                                     PluginLogEntryType.Info,
-                                    true,
                                     `Plugin unloaded (instance ID ${server.instanceId}).`,
                                     server.instanceId
                                 )
@@ -29,8 +29,8 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
                             if (server.ENABLE_PERSISTENT_CONSOLE) {
                                 await server.db.createPluginLogEntry(
                                     pluginConfig,
+                                    PluginLogEntrySource.System,
                                     PluginLogEntryType.Error,
-                                    true,
                                     `Plugin failed to unload (instance ID ${server.instanceId}).`,
                                     server.instanceId
                                 )
@@ -41,8 +41,8 @@ export async function teardownPlugins(server: PluginsServer, pluginConfig?: Plug
             } else if (server.ENABLE_PERSISTENT_CONSOLE) {
                 await server.db.createPluginLogEntry(
                     pluginConfig,
+                    PluginLogEntrySource.System,
                     PluginLogEntryType.Info,
-                    true,
                     `Plugin unloaded (instance ID ${server.instanceId}).`,
                     server.instanceId
                 )

--- a/src/worker/vm/extensions/console.ts
+++ b/src/worker/vm/extensions/console.ts
@@ -2,7 +2,7 @@ import { ConsoleExtension } from '@posthog/plugin-scaffold'
 
 import { status } from '../../../shared/status'
 import { determineNodeEnv, NodeEnv, pluginDigest } from '../../../shared/utils'
-import { PluginConfig, PluginLogEntryType, PluginsServer } from '../../../types'
+import { PluginConfig, PluginLogEntrySource, PluginLogEntryType, PluginsServer } from '../../../types'
 
 function consoleFormat(...args: unknown[]): string {
     return args
@@ -26,7 +26,13 @@ export function createConsole(server: PluginsServer, pluginConfig: PluginConfig)
             return
         }
 
-        await server.db.createPluginLogEntry(pluginConfig, type, false, consoleFormat(...args), server.instanceId)
+        await server.db.createPluginLogEntry(
+            pluginConfig,
+            PluginLogEntrySource.Console,
+            type,
+            consoleFormat(...args),
+            server.instanceId
+        )
     }
 
     return {

--- a/src/worker/vm/extensions/console.ts
+++ b/src/worker/vm/extensions/console.ts
@@ -26,7 +26,7 @@ export function createConsole(server: PluginsServer, pluginConfig: PluginConfig)
             return
         }
 
-        await server.db.createPluginLogEntry(pluginConfig, type, consoleFormat(...args), server.instanceId)
+        await server.db.createPluginLogEntry(pluginConfig, type, false, consoleFormat(...args), server.instanceId)
     }
 
     return {

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -18,24 +18,28 @@ export class LazyPluginVM {
             ) => {
                 try {
                     const vm = await createPluginConfigVM(server, pluginConfig, indexJs)
-                    await server.db.createPluginLogEntry(
-                        pluginConfig,
-                        PluginLogEntryType.Info,
-                        true,
-                        `Plugin loaded (instance ID ${server.instanceId}).`,
-                        server.instanceId
-                    )
+                    if (server.ENABLE_PERSISTENT_CONSOLE) {
+                        await server.db.createPluginLogEntry(
+                            pluginConfig,
+                            PluginLogEntryType.Info,
+                            true,
+                            `Plugin loaded (instance ID ${server.instanceId}).`,
+                            server.instanceId
+                        )
+                    }
                     status.info('🔌', `Loaded ${logInfo}`)
                     void clearError(server, pluginConfig)
                     resolve(vm)
                 } catch (error) {
-                    await server.db.createPluginLogEntry(
-                        pluginConfig,
-                        PluginLogEntryType.Error,
-                        true,
-                        `Plugin failed to load (instance ID ${server.instanceId}).`,
-                        server.instanceId
-                    )
+                    if (server.ENABLE_PERSISTENT_CONSOLE) {
+                        await server.db.createPluginLogEntry(
+                            pluginConfig,
+                            PluginLogEntryType.Error,
+                            true,
+                            `Plugin failed to load (instance ID ${server.instanceId}).`,
+                            server.instanceId
+                        )
+                    }
                     status.warn('⚠️', `Failed to load ${logInfo}`)
                     void processError(server, pluginConfig, error)
                     resolve(null)

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -1,6 +1,13 @@
 import { clearError, processError } from '../../shared/error'
 import { status } from '../../shared/status'
-import { PluginConfig, PluginConfigVMReponse, PluginLogEntryType, PluginsServer, PluginTask } from '../../types'
+import {
+    PluginConfig,
+    PluginConfigVMReponse,
+    PluginLogEntrySource,
+    PluginLogEntryType,
+    PluginsServer,
+    PluginTask,
+} from '../../types'
 import { createPluginConfigVM } from './vm'
 
 export class LazyPluginVM {
@@ -21,8 +28,8 @@ export class LazyPluginVM {
                     if (server.ENABLE_PERSISTENT_CONSOLE) {
                         await server.db.createPluginLogEntry(
                             pluginConfig,
+                            PluginLogEntrySource.System,
                             PluginLogEntryType.Info,
-                            true,
                             `Plugin loaded (instance ID ${server.instanceId}).`,
                             server.instanceId
                         )
@@ -34,8 +41,8 @@ export class LazyPluginVM {
                     if (server.ENABLE_PERSISTENT_CONSOLE) {
                         await server.db.createPluginLogEntry(
                             pluginConfig,
+                            PluginLogEntrySource.System,
                             PluginLogEntryType.Error,
-                            true,
                             `Plugin failed to load (instance ID ${server.instanceId}).`,
                             server.instanceId
                         )

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -606,6 +606,7 @@ test('console.log', async () => {
 
     expect(mockServer.db.createPluginLogEntry).toHaveBeenCalledWith(
         pluginConfig39,
+        'CONSOLE',
         'LOG',
         'logged event',
         expect.anything()


### PR DESCRIPTION
## Changes

This adds registering of plugin errors and load/unload events with plugin logs. Closes #254.

![1](https://user-images.githubusercontent.com/4550621/116083781-5325e200-a69d-11eb-938e-4dbf8e4bc7ed.png)
![2](https://user-images.githubusercontent.com/4550621/116083772-50c38800-a69d-11eb-9822-d9b8e8576759.png)

## Checklist

-   [ ] Jest tests
