### PR TITLE
Annotate update for plugin config errors to include timing

### DIFF
--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -167,6 +167,16 @@ export async function startPluginsServer(
                 server!.statsd?.gauge(`piscina.waitTime.p90`, piscina?.waitTime.p90)
                 server!.statsd?.gauge(`piscina.waitTime.p75`, piscina?.waitTime.p75)
                 server!.statsd?.gauge(`piscina.waitTime.p50`, piscina?.waitTime.p50)
+                server!.statsd?.gauge(`piscina.runTime.average`, piscina?.runTime.average)
+                server!.statsd?.gauge(`piscina.runTime.mean`, piscina?.runTime.mean)
+                server!.statsd?.gauge(`piscina.runTime.stddev`, piscina?.runTime.stddev)
+                server!.statsd?.gauge(`piscina.runTime.min`, piscina?.runTime.min)
+                server!.statsd?.gauge(`piscina.runTime.p99_99`, piscina?.runTime.p99_99)
+                server!.statsd?.gauge(`piscina.runTime.p99`, piscina?.runTime.p99)
+                server!.statsd?.gauge(`piscina.runTime.p95`, piscina?.runTime.p95)
+                server!.statsd?.gauge(`piscina.runTime.p90`, piscina?.runTime.p90)
+                server!.statsd?.gauge(`piscina.runTime.p75`, piscina?.runTime.p75)
+                server!.statsd?.gauge(`piscina.runTime.p50`, piscina?.runTime.p50)
             }
         })
 

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -157,6 +157,16 @@ export async function startPluginsServer(
                 server!.statsd?.gauge(`piscina.utilization`, (piscina?.utilization || 0) * 100)
                 server!.statsd?.gauge(`piscina.threads`, piscina?.threads.length)
                 server!.statsd?.gauge(`piscina.queue_size`, piscina?.queueSize)
+                server!.statsd?.gauge(`piscina.waitTime.average`, piscina?.waitTime.average)
+                server!.statsd?.gauge(`piscina.waitTime.mean`, piscina?.waitTime.mean)
+                server!.statsd?.gauge(`piscina.waitTime.stddev`, piscina?.waitTime.stddev)
+                server!.statsd?.gauge(`piscina.waitTime.min`, piscina?.waitTime.min)
+                server!.statsd?.gauge(`piscina.waitTime.p99_99`, piscina?.waitTime.p99_99)
+                server!.statsd?.gauge(`piscina.waitTime.p99`, piscina?.waitTime.p99)
+                server!.statsd?.gauge(`piscina.waitTime.p95`, piscina?.waitTime.p95)
+                server!.statsd?.gauge(`piscina.waitTime.p90`, piscina?.waitTime.p90)
+                server!.statsd?.gauge(`piscina.waitTime.p75`, piscina?.waitTime.p75)
+                server!.statsd?.gauge(`piscina.waitTime.p50`, piscina?.waitTime.p50)
             }
         })
 

--- a/src/shared/sql.ts
+++ b/src/shared/sql.ts
@@ -46,10 +46,9 @@ export async function setError(
     pluginError: PluginError | null,
     pluginConfig: PluginConfig
 ): Promise<void> {
-    await server.db.postgresQuery('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
-        pluginError,
-        typeof pluginConfig === 'object' ? pluginConfig?.id : pluginConfig,
-        ],
+    await server.db.postgresQuery(
+        'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
+        [pluginError, typeof pluginConfig === 'object' ? pluginConfig?.id : pluginConfig],
         'update_pc_error'
     )
     if (pluginError && server.ENABLE_PERSISTENT_CONSOLE) {

--- a/src/shared/sql.ts
+++ b/src/shared/sql.ts
@@ -49,7 +49,9 @@ export async function setError(
     await server.db.postgresQuery('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
         pluginError,
         typeof pluginConfig === 'object' ? pluginConfig?.id : pluginConfig,
-    ])
+        ],
+        'update_pc_error'
+    )
     if (pluginError && server.ENABLE_PERSISTENT_CONSOLE) {
         await server.db.createPluginLogEntry(
             pluginConfig,

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -133,8 +133,9 @@ test('setError', async () => {
 
     const pluginError: PluginError = { message: 'error happened', time: 'now' }
     await setError(server, pluginError, pluginConfig39)
-    expect(server.db.postgresQuery).toHaveBeenCalledWith('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
-        pluginError,
-        pluginConfig39.id,
-    ])
+    expect(server.db.postgresQuery).toHaveBeenCalledWith(
+        'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
+        [pluginError, pluginConfig39.id],
+        'update_pc_error'
+    )
 })

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -125,10 +125,11 @@ test('setError', async () => {
     server.db.postgresQuery = jest.fn() as any
 
     await setError(server, null, pluginConfig39)
-    expect(server.db.postgresQuery).toHaveBeenCalledWith('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
-        null,
-        pluginConfig39.id,
-    ])
+    expect(server.db.postgresQuery).toHaveBeenCalledWith(
+        'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
+        [null, pluginConfig39.id],
+        'update_pc_error'
+    )
 
     const pluginError: PluginError = { message: 'error happened', time: 'now' }
     await setError(server, pluginError, pluginConfig39)


### PR DESCRIPTION
## Changes

Adding metrics for the sql call to update plugin configs with the error flag. I've seen this one show up a number of times in the logs

Also adding more metrics for piscina worker pool. I have a hunch that the root cause of the issues is around piscina silently running out of capacity and stalling.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
