### PR TITLE
Fix leaky guards, increase kafka timeouts

### DIFF
--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -204,8 +204,10 @@ export class KafkaQueue implements Queue {
     private static buildConsumer(kafka: Kafka): Consumer {
         const consumer = kafka.consumer({
             groupId: 'clickhouse-ingestion',
-            sessionTimeout: 60000,
+            rebalanceTimeout: 120000, // default: 60000
+            sessionTimeout: 60000, // default: 30000
             readUncommitted: false,
+            retry: { retries: 20 },
         })
         const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
         consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -104,7 +104,7 @@ export async function createServer(
             logLevel: logLevel.WARN,
             ssl: kafkaSsl,
         })
-        const producer = kafka.producer()
+        const producer = kafka.producer({ retry: { initialRetryTime: 1000, maxRetryTime: 60000, retries: 20 } })
         await producer?.connect()
 
         kafkaProducer = new KafkaProducerWrapper(producer, statsd, serverConfig)

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -362,6 +362,24 @@ export const createProcessEventTests = (
         ])
     })
 
+    test('capture bad team', async () => {
+        await expect(async () => {
+            await processEvent(
+                'asdfasdfasdf',
+                '',
+                '',
+                ({
+                    event: '$pageview',
+                    properties: { distinct_id: 'asdfasdfasdf', token: team.api_token },
+                } as any) as PluginEvent,
+                1337,
+                now,
+                now,
+                new UUIDT().toString()
+            )
+        }).rejects.toThrowError("No team found with ID 1337. Can't ingest event.")
+    })
+
     test('capture no element', async () => {
         await createPerson(server, team, ['asdfasdfasdf'])
 


### PR DESCRIPTION
## Changes

- When capture (rightly so) throws an exception, the timeout guards keep running, resulting in needless noise. This should clean up the errors just a bit.
- Also increased the time Kafka waits for new servers to join before rebalancing from 1min to 2min. Let's see if this helps things or needs to be reverted.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
