### PR TITLE
Postgres tags + Piscina stats

### DIFF
--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -68,7 +68,7 @@ export class KafkaQueue implements Queue {
 
         const processingTimeout = timeoutGuard('Still running plugins on events. Timeout warning after 30 sec!', {
             eventCount: pluginEvents.length,
-            piscina: getPiscinaStats(this.piscina),
+            piscina: JSON.stringify(getPiscinaStats(this.piscina)),
         })
         const processingBatches = groupIntoBatches(pluginEvents, maxBatchSize)
         const processedEvents = (
@@ -95,13 +95,13 @@ export class KafkaQueue implements Queue {
 
         const ingestionTimeout = timeoutGuard('Still ingesting events. Timeout warning after 30 sec!', {
             eventCount: processedEvents.length,
-            piscina: getPiscinaStats(this.piscina),
+            piscina: JSON.stringify(getPiscinaStats(this.piscina)),
         })
 
         const ingestOneEvent = async (event: PluginEvent) => {
             const singleIngestionTimeout = timeoutGuard('After 30 seconds still ingesting event', {
                 event: JSON.stringify(event),
-                piscina: getPiscinaStats(this.piscina),
+                piscina: JSON.stringify(getPiscinaStats(this.piscina)),
             })
             const singleIngestionTimer = new Date()
             try {

--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -15,13 +15,13 @@ export class KafkaQueue implements Queue {
     private consumer: Consumer
     private wasConsumerRan: boolean
     private processEventBatch: (batch: PluginEvent[]) => Promise<PluginEvent[]>
-    private saveEvent: (event: PluginEvent) => Promise<void>
+    private ingestEvent: (event: PluginEvent) => Promise<void>
 
     constructor(
         pluginsServer: PluginsServer,
         piscina: Piscina,
         processEventBatch: (batch: PluginEvent[]) => Promise<any>,
-        saveEvent: (event: PluginEvent) => Promise<void>
+        ingestEvent: (event: PluginEvent) => Promise<void>
     ) {
         this.pluginsServer = pluginsServer
         this.piscina = piscina
@@ -29,7 +29,7 @@ export class KafkaQueue implements Queue {
         this.consumer = KafkaQueue.buildConsumer(this.kafka)
         this.wasConsumerRan = false
         this.processEventBatch = processEventBatch
-        this.saveEvent = saveEvent
+        this.ingestEvent = ingestEvent
     }
 
     private async eachBatch({
@@ -105,7 +105,7 @@ export class KafkaQueue implements Queue {
             })
             const singleIngestionTimer = new Date()
             try {
-                await this.saveEvent(event)
+                await this.ingestEvent(event)
             } catch (error) {
                 status.info('🔔', error)
                 Sentry.captureException(error)

--- a/src/main/mmdb.ts
+++ b/src/main/mmdb.ts
@@ -75,14 +75,16 @@ async function fetchAndInsertFreshMmdb(server: PluginsServer): Promise<ReaderMod
             key, content_type, file_name, file_size, contents, plugin_config_id, team_id
         ) VALUES ($1, $2, $3, $4, $5, NULL, NULL) RETURNING *
     `,
-        [MMDB_ATTACHMENT_KEY, contentType, filename + '.br', brotliContents.byteLength, brotliContents]
+        [MMDB_ATTACHMENT_KEY, contentType, filename + '.br', brotliContents.byteLength, brotliContents],
+        'insertGeoIpAttachment'
     )
     // Ensure that there's no old attachments lingering
     await db.postgresQuery(
         `
         DELETE FROM posthog_pluginattachment WHERE key = $1 AND id != $2
     `,
-        [MMDB_ATTACHMENT_KEY, newAttachmentResults.rows[0].id]
+        [MMDB_ATTACHMENT_KEY, newAttachmentResults.rows[0].id],
+        'deleteGeoIpAttachment'
     )
     status.info('💾', `Saved ${filename} into the database`)
 
@@ -153,7 +155,8 @@ export async function prepareMmdb(
         WHERE key = $1 AND plugin_config_id IS NULL AND team_id IS NULL
         ORDER BY file_name ASC
     `,
-        [MMDB_ATTACHMENT_KEY]
+        [MMDB_ATTACHMENT_KEY],
+        'fetchGeoIpAttachment'
     )
     if (!readResults.rowCount) {
         status.info('⬇️', `Fetching ${MMDB_ATTACHMENT_KEY} for the first time`)

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -247,6 +247,7 @@ export class DB {
                 SELECT * FROM person JOIN (
                     SELECT id, max(_timestamp) as _timestamp FROM person GROUP BY team_id, id
                 ) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp
+                FINAL
             `
             return (await this.clickhouseQuery(query)).data.map((row) => {
                 const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -244,10 +244,9 @@ export class DB {
     public async fetchPersons(database: Database = Database.Postgres): Promise<Person[] | ClickHousePerson[]> {
         if (database === Database.ClickHouse) {
             const query = `
-                SELECT * FROM person JOIN (
+                SELECT * FROM person FINAL JOIN (
                     SELECT id, max(_timestamp) as _timestamp FROM person GROUP BY team_id, id
                 ) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp
-                FINAL
             `
             return (await this.clickhouseQuery(query)).data.map((row) => {
                 const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row

--- a/src/shared/db.ts
+++ b/src/shared/db.ts
@@ -75,8 +75,8 @@ export class DB {
 
     public postgresQuery<R extends QueryResultRow = any, I extends any[] = any[]>(
         queryTextOrConfig: string | QueryConfig<I>,
-        values?: I,
-        tag?: string
+        values: I | undefined,
+        tag: string
     ): Promise<QueryResult<R>> {
         return instrumentQuery(this.statsd, 'query.postgres', tag, async () => {
             const timeout = timeoutGuard('Postgres slow query warning after 30 sec', { queryTextOrConfig, values })
@@ -463,10 +463,11 @@ export class DB {
         personDistinctId: PersonDistinctId,
         moveToPerson: Person
     ): Promise<void> {
-        await this.postgresQuery(`UPDATE posthog_persondistinctid SET person_id = $1 WHERE id = $2`, [
-            moveToPerson.id,
-            personDistinctId.id,
-        ])
+        await this.postgresQuery(
+            `UPDATE posthog_persondistinctid SET person_id = $1 WHERE id = $2`,
+            [moveToPerson.id, personDistinctId.id],
+            'updateDistinctIdPerson'
+        )
         if (this.kafkaProducer) {
             const clickhouseModel: ClickHousePersonDistinctId = { ...personDistinctId, person_id: moveToPerson.uuid }
             await this.kafkaProducer.queueMessage({
@@ -506,7 +507,7 @@ export class DB {
                 ) || []
             )
         } else {
-            const result = await this.postgresQuery('SELECT * FROM posthog_event')
+            const result = await this.postgresQuery('SELECT * FROM posthog_event', undefined, 'fetchAllEvents')
             return result.rows as Event[]
         }
     }
@@ -524,7 +525,11 @@ export class DB {
             })
             return events
         } else {
-            const result = await this.postgresQuery('SELECT * FROM posthog_sessionrecordingevent')
+            const result = await this.postgresQuery(
+                'SELECT * FROM posthog_sessionrecordingevent',
+                undefined,
+                'fetchAllSessionRecordingEvents'
+            )
             return result.rows as PostgresSessionRecordingEvent[]
         }
     }
@@ -541,7 +546,7 @@ export class DB {
             const chain = events?.[0]?.elements_chain
             return chainToElements(chain)
         } else {
-            return (await this.postgresQuery('SELECT * FROM posthog_element')).rows
+            return (await this.postgresQuery('SELECT * FROM posthog_element', undefined, 'fetchAllElements')).rows
         }
     }
 
@@ -592,7 +597,8 @@ export class DB {
         if (this.kafkaProducer) {
             return (await this.clickhouseQuery(`SELECT * FROM plugin_log_entries`)).data as PluginLogEntry[]
         } else {
-            return (await this.postgresQuery('SELECT * FROM posthog_pluginlogentry')).rows as PluginLogEntry[]
+            return (await this.postgresQuery('SELECT * FROM posthog_pluginlogentry', undefined, 'fetchAllPluginLogs'))
+                .rows as PluginLogEntry[]
         }
     }
 

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -103,6 +103,9 @@ export async function createServer(
             brokers: serverConfig.KAFKA_HOSTS.split(','),
             logLevel: logLevel.WARN,
             ssl: kafkaSsl,
+            connectionTimeout: 3000, // default: 1000
+            authenticationTimeout: 3000, // default: 1000
+            retry: { initialRetryTime: 1000, maxRetryTime: 60000, retries: 20 },
         })
         const producer = kafka.producer({ retry: { initialRetryTime: 1000, maxRetryTime: 60000, retries: 20 } })
         await producer?.connect()

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,3 +1,4 @@
+import Piscina from '@posthog/piscina'
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import AdmZip from 'adm-zip'
@@ -477,4 +478,32 @@ export function determineNodeEnv(): NodeEnv {
         return NodeEnv.Development
     }
     return NodeEnv.Production
+}
+
+export function getPiscinaStats(piscina: Piscina): Record<string, number> {
+    return {
+        utilization: (piscina.utilization || 0) * 100,
+        threads: piscina.threads.length,
+        queue_size: piscina.queueSize,
+        'waitTime.average': piscina.waitTime.average,
+        'waitTime.mean': piscina.waitTime.mean,
+        'waitTime.stddev': piscina.waitTime.stddev,
+        'waitTime.min': piscina.waitTime.min,
+        'waitTime.p99_99': piscina.waitTime.p99_99,
+        'waitTime.p99': piscina.waitTime.p99,
+        'waitTime.p95': piscina.waitTime.p95,
+        'waitTime.p90': piscina.waitTime.p90,
+        'waitTime.p75': piscina.waitTime.p75,
+        'waitTime.p50': piscina.waitTime.p50,
+        'runTime.average': piscina.runTime.average,
+        'runTime.mean': piscina.runTime.mean,
+        'runTime.stddev': piscina.runTime.stddev,
+        'runTime.min': piscina.runTime.min,
+        'runTime.p99_99': piscina.runTime.p99_99,
+        'runTime.p99': piscina.runTime.p99,
+        'runTime.p95': piscina.runTime.p95,
+        'runTime.p90': piscina.runTime.p90,
+        'runTime.p75': piscina.runTime.p75,
+        'runTime.p50': piscina.runTime.p50,
+    }
 }

--- a/src/worker/vm/extensions/storage.ts
+++ b/src/worker/vm/extensions/storage.ts
@@ -6,7 +6,8 @@ export function createStorage(server: PluginsServer, pluginConfig: PluginConfig)
     const get = async function (key: string, defaultValue: unknown): Promise<unknown> {
         const result = await server.db.postgresQuery(
             'SELECT * FROM posthog_pluginstorage WHERE "plugin_config_id"=$1 AND "key"=$2 LIMIT 1',
-            [pluginConfig.id, key]
+            [pluginConfig.id, key],
+            'storageGet'
         )
         return result?.rows.length === 1 ? JSON.parse(result.rows[0].value) : defaultValue
     }
@@ -14,7 +15,8 @@ export function createStorage(server: PluginsServer, pluginConfig: PluginConfig)
         if (typeof value === 'undefined') {
             await server.db.postgresQuery(
                 'DELETE FROM posthog_pluginstorage WHERE "plugin_config_id"=$1 AND "key"=$2',
-                [pluginConfig.id, key]
+                [pluginConfig.id, key],
+                'storageDelete'
             )
         } else {
             await server.db.postgresQuery(
@@ -24,7 +26,8 @@ export function createStorage(server: PluginsServer, pluginConfig: PluginConfig)
                     ON CONFLICT ("plugin_config_id", "key")
                     DO UPDATE SET value = $3
                 `,
-                [pluginConfig.id, key, JSON.stringify(value)]
+                [pluginConfig.id, key, JSON.stringify(value)],
+                'storageSet'
             )
         }
     }

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -142,7 +142,7 @@ export async function createUserTeamAndOrganization(
 }
 
 export async function getTeams(server: PluginsServer): Promise<Team[]> {
-    return (await server.db.postgresQuery('SELECT * FROM posthog_team ORDER BY id')).rows
+    return (await server.db.postgresQuery('SELECT * FROM posthog_team ORDER BY id', undefined, 'fetchAllTeams')).rows
 }
 
 export async function getFirstTeam(server: PluginsServer): Promise<Team> {

--- a/tests/postgres/teardown.test.ts
+++ b/tests/postgres/teardown.test.ts
@@ -73,9 +73,11 @@ describe('teardown', () => {
 
         await delay(100)
 
-        await server.db.postgresQuery('update posthog_pluginconfig set updated_at = now() where id = $1', [
-            pluginConfig39.id,
-        ])
+        await server.db.postgresQuery(
+            'update posthog_pluginconfig set updated_at = now() where id = $1',
+            [pluginConfig39.id],
+            'testTag'
+        )
         const event1 = await piscina!.runTask({ task: 'processEvent', args: { event: { ...defaultEvent } } })
         expect(event1.properties.storage).toBe('nope')
 

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -203,7 +203,11 @@ export const createProcessEventTests = (
     })
 
     test('capture new person', async () => {
-        await server.db.postgresQuery(`UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`, [true, team.id])
+        await server.db.postgresQuery(
+            `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`,
+            [true, team.id],
+            'testTag'
+        )
         team = await getFirstTeam(server)
 
         expect(team.event_names).toEqual([])
@@ -552,7 +556,7 @@ export const createProcessEventTests = (
     })
 
     test('anonymized ip capture', async () => {
-        await server.db.postgresQuery('update posthog_team set anonymize_ips = $1', [true])
+        await server.db.postgresQuery('update posthog_team set anonymize_ips = $1', [true], 'testTag')
         await createPerson(server, team, ['asdfasdfasdf'])
 
         await processEvent(
@@ -831,7 +835,11 @@ export const createProcessEventTests = (
     })
 
     test('capture first team event', async () => {
-        await server.db.postgresQuery(`UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`, [false, team.id])
+        await server.db.postgresQuery(
+            `UPDATE posthog_team SET ingested_event = $1 WHERE id = $2`,
+            [false, team.id],
+            'testTag'
+        )
 
         eventsProcessor.posthog = {
             identify: jest.fn((distinctId) => true),

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -30,7 +30,7 @@ test('getPluginAttachmentRows', async () => {
 
     const rows1 = await getPluginAttachmentRows(server)
     expect(rows1).toEqual(rowsExpected)
-    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
+    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
     const rows2 = await getPluginAttachmentRows(server)
     expect(rows2).toEqual(rowsExpected)
 })
@@ -55,7 +55,7 @@ test('getPluginConfigRows', async () => {
 
     const rows1 = await getPluginConfigRows(server)
     expect(rows1).toEqual(rowsExpected)
-    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
+    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
     const rows2 = await getPluginConfigRows(server)
     expect(rows2).toEqual(rowsExpected)
 })
@@ -105,7 +105,7 @@ test('getPluginRows', async () => {
 
     const rows1 = await getPluginRows(server)
     expect(rows1).toEqual(rowsExpected)
-    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'")
+    await server.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
     const rows2 = await getPluginRows(server)
     expect(rows2).toEqual(rowsExpected)
 })
@@ -128,7 +128,7 @@ test('setError', async () => {
     expect(server.db.postgresQuery).toHaveBeenCalledWith(
         'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
         [null, pluginConfig39.id],
-        'update_pc_error'
+        'updatePluginConfigError'
     )
 
     const pluginError: PluginError = { message: 'error happened', time: 'now' }
@@ -136,6 +136,6 @@ test('setError', async () => {
     expect(server.db.postgresQuery).toHaveBeenCalledWith(
         'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
         [pluginError, pluginConfig39.id],
-        'update_pc_error'
+        'updatePluginConfigError'
     )
 })


### PR DESCRIPTION
## Changes

- Add tags to the last postgres queries without them
- Add piscina stats to all ingestion timeout guards
- Increase Kafka connection and authentication timeouts (1sec -> 3sec)

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
