### PR TITLE
Autorestart first steps

### DIFF
--- a/src/main/queue.ts
+++ b/src/main/queue.ts
@@ -27,12 +27,18 @@ export async function startQueue(
 ): Promise<Queue> {
     const mergedWorkerMethods = {
         processEvent: (event: PluginEvent) => {
+            server.lastActivity = new Date().valueOf()
+            server.lastActivityType = 'processEvent'
             return piscina.runTask({ task: 'processEvent', args: { event } })
         },
         processEventBatch: (batch: PluginEvent[]) => {
+            server.lastActivity = new Date().valueOf()
+            server.lastActivityType = 'processEventBatch'
             return piscina.runTask({ task: 'processEventBatch', args: { batch } })
         },
         ingestEvent: (event: PluginEvent) => {
+            server.lastActivity = new Date().valueOf()
+            server.lastActivityType = 'ingestEvent'
             return piscina.runTask({ task: 'ingestEvent', args: { event } })
         },
         ...workerMethods,

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -60,6 +60,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         INTERNAL_MMDB_SERVER_PORT: 0,
         PLUGIN_SERVER_IDLE: false,
         ENABLE_PERSISTENT_CONSOLE: false, // TODO: remove when persistent console ships in main repo
+        STALENESS_RESTART_SECONDS: 0,
     }
 }
 
@@ -101,6 +102,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         DISTINCT_ID_LRU_SIZE: 'size of persons distinct ID LRU cache',
         INTERNAL_MMDB_SERVER_PORT: 'port of the internal server used for IP location (0 means random)',
         PLUGIN_SERVER_IDLE: 'whether to disengage the plugin server, e.g. for development',
+        STALENESS_RESTART_SECONDS: 'trigger a restart if no event ingested for this duration',
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     INTERNAL_MMDB_SERVER_PORT: number
     PLUGIN_SERVER_IDLE: boolean
     ENABLE_PERSISTENT_CONSOLE: boolean
+    STALENESS_RESTART_SECONDS: number
 }
 
 export interface PluginsServer extends PluginsServerConfig {
@@ -93,6 +94,9 @@ export interface PluginsServer extends PluginsServerConfig {
     pluginSchedule: Record<string, PluginConfigId[]> | null
     pluginSchedulePromises: Record<string, Record<PluginConfigId, Promise<any> | null>>
     eventsProcessor: EventsProcessor
+    // diagnostics
+    lastActivity: number
+    lastActivityType: string
 }
 
 export interface Pausable {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,8 +1,12 @@
+import * as Sentry from '@sentry/node'
+
 import { startPluginsServer } from '../src/main/pluginsServer'
+import { delay } from '../src/shared/utils'
 import { LogLevel } from '../src/types'
 import { makePiscina } from '../src/worker/piscina'
 import { resetTestDatabase } from './helpers/sql'
 
+jest.mock('@sentry/node')
 jest.mock('../src/shared/sql')
 jest.setTimeout(60000) // 60 sec timeout
 
@@ -20,6 +24,31 @@ test('startPluginsServer', async () => {
         },
         makePiscina
     )
+
+    await pluginsServer.stop()
+})
+
+test('plugin server staleness check', async () => {
+    const testCode = `
+        async function processEvent (event) {
+            return event
+        }
+    `
+    await resetTestDatabase(testCode)
+    const pluginsServer = await startPluginsServer(
+        {
+            WORKER_CONCURRENCY: 2,
+            STALENESS_RESTART_SECONDS: 5,
+            LOG_LEVEL: LogLevel.Debug,
+        },
+        makePiscina
+    )
+
+    await delay(10000)
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(`Plugin Server has not ingested events for over 5 seconds!`, {
+        extra: { instanceId: expect.any(String), lastActivity: expect.any(String), lastActivityType: 'serverStart' },
+    })
 
     await pluginsServer.stop()
 })


### PR DESCRIPTION
## Changes

- Because THE SHOW MUST GO ON... and nobody wants to manually restart servers at 3am
- If the plugin server has not ingested an event in X time units (default off), send an alert to sentry.
- This should be set to something like 5min in cloud.
- TODO: also restart the server, but I'd like to first just get the alerting live before I add the SIGTERM.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
