### PR TITLE
Sync clear error

### DIFF
--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -35,7 +35,7 @@ export class LazyPluginVM {
                         )
                     }
                     status.info('🔌', `Loaded ${logInfo}`)
-                    void clearError(server, pluginConfig)
+                    await clearError(server, pluginConfig)
                     resolve(vm)
                 } catch (error) {
                     if (server.ENABLE_PERSISTENT_CONSOLE) {
@@ -48,7 +48,7 @@ export class LazyPluginVM {
                         )
                     }
                     status.warn('⚠️', `Failed to load ${logInfo}`)
-                    void processError(server, pluginConfig, error)
+                    await processError(server, pluginConfig, error)
                     resolve(null)
                 }
             }


### PR DESCRIPTION
## Changes

- This `UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2` seems to time out often. 
- Let's see if doing it sync (instead of delegating to the back of the JS event loop) fixes the stability we're having with this line.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
