### PR TITLE
Revert "Sync clear error"

### DIFF
--- a/src/shared/error.ts
+++ b/src/shared/error.ts
@@ -32,5 +32,8 @@ export async function processError(
 }
 
 export async function clearError(server: PluginsServer, pluginConfig: PluginConfig): Promise<void> {
-    await setError(server, null, pluginConfig)
+    // running this may causes weird deadlocks with piscina and vms, so avoiding if possible
+    if (pluginConfig.error) {
+        await setError(server, null, pluginConfig)
+    }
 }

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -35,7 +35,7 @@ export class LazyPluginVM {
                         )
                     }
                     status.info('🔌', `Loaded ${logInfo}`)
-                    await clearError(server, pluginConfig)
+                    void clearError(server, pluginConfig)
                     resolve(vm)
                 } catch (error) {
                     if (server.ENABLE_PERSISTENT_CONSOLE) {
@@ -48,7 +48,7 @@ export class LazyPluginVM {
                         )
                     }
                     status.warn('⚠️', `Failed to load ${logInfo}`)
-                    await processError(server, pluginConfig, error)
+                    void processError(server, pluginConfig, error)
                     resolve(null)
                 }
             }

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -35,9 +35,7 @@ export class LazyPluginVM {
                         )
                     }
                     status.info('🔌', `Loaded ${logInfo}`)
-                    if (pluginConfig.error) {
-                        void clearError(server, pluginConfig)
-                    }
+                    void clearError(server, pluginConfig)
                     resolve(vm)
                 } catch (error) {
                     if (server.ENABLE_PERSISTENT_CONSOLE) {


### PR DESCRIPTION
Reverts PostHog/plugin-server#342

Context from slack:
- Full thread at https://posthog.slack.com/archives/C0185UNBSJZ/p1619534371059900
- Michael pointed out that this range contains an error
- I originally marked this as void not await due to some deadlocking I was seeing locally - https://github.com/PostHog/plugin-server/pull/234/commits/7ebed6feec1132e5dcdb4da33a39510e1c667c6d as part of https://github.com/PostHog/plugin-server/pull/234

Not sure _why_ this would cause errors but it seems to be related to how pisciana/workers in node work.

PRs > Issues but will let you take it from here