### PR TITLE
Remove Kafka timeouts

### DIFF
--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -214,7 +214,6 @@ export class KafkaQueue implements Queue {
             rebalanceTimeout: 120000, // default: 60000
             sessionTimeout: 60000, // default: 30000
             readUncommitted: false,
-            retry: { retries: 20 },
         })
         const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
         consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -105,9 +105,8 @@ export async function createServer(
             ssl: kafkaSsl,
             connectionTimeout: 3000, // default: 1000
             authenticationTimeout: 3000, // default: 1000
-            retry: { initialRetryTime: 1000, maxRetryTime: 60000, retries: 20 },
         })
-        const producer = kafka.producer({ retry: { initialRetryTime: 1000, maxRetryTime: 60000, retries: 20 } })
+        const producer = kafka.producer()
         await producer?.connect()
 
         kafkaProducer = new KafkaProducerWrapper(producer, statsd, serverConfig)


### PR DESCRIPTION
## Changes

- Removes some variables set earlier today (mostly for kafka producer and other default retries)
- Keeps this new ones for the consumer:
   - `sessionTimeout: 60000, // default: 30000` 
   - Plugins + ingestion with may go over 30sec in case of congestion. The worst thing we want then is to start rebalancing
- Keep these new ones for the server:
   - `connectionTimeout: 3000, // default: 1000`
   - `authenticationTimeout: 3000, // default: 1000`


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
