### PR TITLE
Do not run getPiscinaStats 3x per event

### DIFF
--- a/src/main/ingestion/kafka-queue.ts
+++ b/src/main/ingestion/kafka-queue.ts
@@ -6,7 +6,7 @@ import { PluginsServer, Queue } from 'types'
 
 import { timeoutGuard } from '../../shared/ingestion/utils'
 import { status } from '../../shared/status'
-import { getPiscinaStats, groupIntoBatches, killGracefully, sanitizeEvent } from '../../shared/utils'
+import { groupIntoBatches, killGracefully, sanitizeEvent } from '../../shared/utils'
 
 export class KafkaQueue implements Queue {
     private pluginsServer: PluginsServer
@@ -68,7 +68,6 @@ export class KafkaQueue implements Queue {
 
         const processingTimeout = timeoutGuard('Still running plugins on events. Timeout warning after 30 sec!', {
             eventCount: pluginEvents.length,
-            piscina: JSON.stringify(getPiscinaStats(this.piscina)),
         })
         const processingBatches = groupIntoBatches(pluginEvents, maxBatchSize)
         const processedEvents = (
@@ -95,13 +94,11 @@ export class KafkaQueue implements Queue {
 
         const ingestionTimeout = timeoutGuard('Still ingesting events. Timeout warning after 30 sec!', {
             eventCount: processedEvents.length,
-            piscina: JSON.stringify(getPiscinaStats(this.piscina)),
         })
 
         const ingestOneEvent = async (event: PluginEvent) => {
             const singleIngestionTimeout = timeoutGuard('After 30 seconds still ingesting event', {
                 event: JSON.stringify(event),
-                piscina: JSON.stringify(getPiscinaStats(this.piscina)),
             })
             const singleIngestionTimer = new Date()
             try {


### PR DESCRIPTION
## Changes

Calling `getPiscinaStats` 3x per event caused a 100x slowdown in ingestion.

from:

```
    [MAIN] 09:43:28 🧩 Kafka batch of 1551 events completed in 906ms (plugins: 49ms, ingestion: 857ms)
```

to:

```
    [MAIN] 09:40:04 🧩 Kafka batch of 1551 events completed in 90306ms (plugins: 78ms, ingestion: 90228ms)
```

The funny thing, this value would make sense when the timeoutGuard fires, not while creating the guard. So it was a bug in any case!

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
