### PR TITLE
Kafka producer retries

### DIFF
--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -188,7 +188,7 @@ export async function startPluginsServer(
                         `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
                         extra
                     )
-                    setTimeout(() => process.kill(process.pid, 'SIGINT'), 1000)
+                    setTimeout(() => process.kill(process.pid, 'SIGTERM'), 1000)
                     setTimeout(() => process.kill(process.pid, 'SIGTERM'), 60000)
                     setTimeout(() => process.kill(process.pid, 'SIGKILL'), 120000)
                 }

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -188,6 +188,7 @@ export async function startPluginsServer(
                         `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
                         extra
                     )
+                    server.statsd?.increment(`alerts.stale_plugin_server_restarted`)
                     setTimeout(() => process.kill(process.pid, 'SIGTERM'), 1000)
                     setTimeout(() => process.kill(process.pid, 'SIGTERM'), 60000)
                     setTimeout(() => process.kill(process.pid, 'SIGKILL'), 120000)

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -189,9 +189,14 @@ export async function startPluginsServer(
                         extra
                     )
                     server.statsd?.increment(`alerts.stale_plugin_server_restarted`)
-                    setTimeout(() => process.kill(process.pid, 'SIGTERM'), 1000)
-                    setTimeout(() => process.kill(process.pid, 'SIGTERM'), 60000)
-                    setTimeout(() => process.kill(process.pid, 'SIGKILL'), 120000)
+
+                    // In tests, only call SIGTERM once to avoid leaky tests.
+                    // In production, kill two more times if the first one fails.
+                    setTimeout(() => process.kill(process.pid, 'SIGTERM'), 100)
+                    if (process.env.NODE_ENV !== 'test') {
+                        setTimeout(() => process.kill(process.pid, 'SIGTERM'), 60000)
+                        setTimeout(() => process.kill(process.pid, 'SIGKILL'), 120000)
+                    }
                 }
             }, Math.min(serverConfig.STALENESS_RESTART_SECONDS, 10000))
         }

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -176,17 +176,21 @@ export async function startPluginsServer(
                         instanceId: server.instanceId.toString(),
                         lastActivity: server.lastActivity ? new Date(server.lastActivity).toISOString() : null,
                         lastActivityType: server.lastActivityType,
+                        piscina: piscina ? JSON.stringify(getPiscinaStats(piscina)) : null,
                     }
                     Sentry.captureMessage(
-                        `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds!`,
+                        `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
                         {
                             extra,
                         }
                     )
                     console.log(
-                        `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds!`,
+                        `Plugin Server has not ingested events for over ${serverConfig.STALENESS_RESTART_SECONDS} seconds! Rebooting.`,
                         extra
                     )
+                    setTimeout(() => process.kill(process.pid, 'SIGINT'), 1000)
+                    setTimeout(() => process.kill(process.pid, 'SIGTERM'), 60000)
+                    setTimeout(() => process.kill(process.pid, 'SIGKILL'), 120000)
                 }
             }, Math.min(serverConfig.STALENESS_RESTART_SECONDS, 10000))
         }

--- a/src/shared/server.ts
+++ b/src/shared/server.ts
@@ -106,7 +106,7 @@ export async function createServer(
             connectionTimeout: 3000, // default: 1000
             authenticationTimeout: 3000, // default: 1000
         })
-        const producer = kafka.producer()
+        const producer = kafka.producer({ retry: { retries: 10, initialRetryTime: 1000, maxRetryTime: 30 } })
         await producer?.connect()
 
         kafkaProducer = new KafkaProducerWrapper(producer, statsd, serverConfig)

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -94,8 +94,11 @@ export class EventsProcessor {
             const timeout1 = timeoutGuard('Still running "handleIdentifyOrAlias". Timeout warning after 30 sec!', {
                 eventUuid,
             })
-            await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
-            clearTimeout(timeout1)
+            try {
+                await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
+            } finally {
+                clearTimeout(timeout1)
+            }
 
             let result: IEvent | SessionRecordingEvent
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -28,27 +28,58 @@ test('startPluginsServer', async () => {
     await pluginsServer.stop()
 })
 
-test('plugin server staleness check', async () => {
-    const testCode = `
-        async function processEvent (event) {
-            return event
-        }
-    `
-    await resetTestDatabase(testCode)
-    const pluginsServer = await startPluginsServer(
-        {
-            WORKER_CONCURRENCY: 2,
-            STALENESS_RESTART_SECONDS: 5,
-            LOG_LEVEL: LogLevel.Debug,
-        },
-        makePiscina
-    )
+describe('plugin server staleness check', () => {
+    const realProcess = process
+    const killMock = jest.fn()
 
-    await delay(10000)
-
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(`Plugin Server has not ingested events for over 5 seconds!`, {
-        extra: { instanceId: expect.any(String), lastActivity: expect.any(String), lastActivityType: 'serverStart' },
+    beforeAll(() => {
+        global.process = new Proxy(process, {
+            get(target, property: keyof typeof process) {
+                if (property === 'kill') {
+                    return killMock
+                }
+                return realProcess[property]
+            },
+        })
     })
 
-    await pluginsServer.stop()
+    afterAll(() => {
+        global.process = realProcess
+    })
+
+    test('test if the server terminates', async () => {
+        const testCode = `
+            async function processEvent (event) {
+                return event
+            }
+        `
+        await resetTestDatabase(testCode)
+
+        const pluginsServer = await startPluginsServer(
+            {
+                WORKER_CONCURRENCY: 2,
+                STALENESS_RESTART_SECONDS: 5,
+                LOG_LEVEL: LogLevel.Debug,
+            },
+            makePiscina
+        )
+
+        await delay(10000)
+
+        expect(killMock).toHaveBeenCalledWith(process.pid, 'SIGTERM')
+
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+            `Plugin Server has not ingested events for over 5 seconds! Rebooting.`,
+            {
+                extra: {
+                    instanceId: expect.any(String),
+                    lastActivity: expect.any(String),
+                    lastActivityType: 'serverStart',
+                    piscina: expect.any(String),
+                },
+            }
+        )
+
+        await pluginsServer.stop()
+    })
 })


### PR DESCRIPTION
## Changes

- Bump Kafka producer retries from 5x to 10x
- Actually kill the server if no event ingested in 5min if the `STALENESS_RESTART_SECONDS` env is set. Should help with getting paged.
- Related: https://github.com/PostHog/plugin-server/issues/348

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
