### PR TITLE
onEvent & onSnapshot

### DIFF
--- a/src/main/ingestion-queues/ingest-event.ts
+++ b/src/main/ingestion-queues/ingest-event.ts
@@ -1,0 +1,103 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import * as Sentry from '@sentry/node'
+
+import { PluginsServer, WorkerMethods } from '../../types'
+import { timeoutGuard } from '../../utils/db/utils'
+import { status } from '../../utils/status'
+
+export async function ingestEvent(
+    server: PluginsServer,
+    workerMethods: WorkerMethods,
+    event: PluginEvent,
+    checkAndPause?: () => void // pause incoming messages if we are slow in getting them out again
+): Promise<void> {
+    const eachEventStartTimer = new Date()
+    const isSnapshot = event.event === '$snapshot'
+
+    let processedEvent: PluginEvent | null = event
+
+    checkAndPause?.()
+
+    // run processEvent on all events that are not $snapshot
+    if (!isSnapshot) {
+        processedEvent = await runInstrumentedFunction({
+            server,
+            event,
+            func: (event) => workerMethods.processEvent(event),
+            statsKey: 'kafka_queue.single_event',
+            timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
+        })
+    }
+
+    checkAndPause?.()
+
+    if (processedEvent) {
+        await Promise.all([
+            runInstrumentedFunction({
+                server,
+                event: processedEvent,
+                func: (event) => workerMethods.ingestEvent(event),
+                statsKey: 'kafka_queue.single_ingestion',
+                timeoutMessage: 'After 30 seconds still ingesting event',
+            }),
+            runInstrumentedFunction({
+                server,
+                event: processedEvent,
+                func: (event) => workerMethods[isSnapshot ? 'onSnapshot' : 'onEvent'](event),
+                statsKey: `kafka_queue.single_${isSnapshot ? 'on_snapshot' : 'on_event'}`,
+                timeoutMessage: `After 30 seconds still running ${isSnapshot ? 'onSnapshot' : 'onEvent'}`,
+            }),
+        ])
+    }
+
+    server.statsd?.timing('kafka_queue.each_event', eachEventStartTimer)
+
+    countAndLogEvents()
+}
+
+async function runInstrumentedFunction({
+    server,
+    timeoutMessage,
+    event,
+    func,
+    statsKey,
+}: {
+    server: PluginsServer
+    event: PluginEvent
+    timeoutMessage: string
+    statsKey: string
+    func: (event: PluginEvent) => Promise<any>
+}): Promise<any> {
+    const timeout = timeoutGuard(timeoutMessage, {
+        event: JSON.stringify(event),
+    })
+    const timer = new Date()
+    try {
+        return await func(event)
+    } catch (error) {
+        status.info('🔔', error)
+        Sentry.captureException(error)
+        throw error
+    } finally {
+        server.statsd?.timing(statsKey, timer)
+        clearTimeout(timeout)
+    }
+}
+
+let messageCounter = 0
+let messageLogDate = 0
+
+function countAndLogEvents(): void {
+    const now = new Date().valueOf()
+    messageCounter++
+    if (now - messageLogDate > 10000) {
+        status.info(
+            '🕒',
+            `Processed ${messageCounter} events${
+                messageLogDate === 0 ? '' : ` in ${Math.round((now - messageLogDate) / 10) / 100}s`
+            }`
+        )
+        messageCounter = 0
+        messageLogDate = now
+    }
+}

--- a/src/main/ingestion-queues/kafka-queue.ts
+++ b/src/main/ingestion-queues/kafka-queue.ts
@@ -59,20 +59,20 @@ export class KafkaQueue implements Queue {
         if (processedEvent) {
             await Promise.all([
                 this.runInstrumentedFunction({
-                    event,
+                    event: processedEvent,
                     func: (event) => this.workerMethods.ingestEvent(event),
                     statsKey: 'kafka_queue.single_ingestion',
                     timeoutMessage: 'After 30 seconds still ingesting event',
                 }),
                 processedEvent.event === '$snapshot'
                     ? this.runInstrumentedFunction({
-                          event,
+                          event: processedEvent,
                           func: (event) => this.workerMethods.onSnapshot(event),
                           statsKey: 'kafka_queue.single_on_snapshot',
                           timeoutMessage: 'After 30 seconds still running onSnapshot',
                       })
                     : this.runInstrumentedFunction({
-                          event,
+                          event: processedEvent,
                           func: (event) => this.workerMethods.onEvent(event),
                           statsKey: 'kafka_queue.single_on_event',
                           timeoutMessage: 'After 30 seconds still running onEvent',

--- a/src/main/ingestion-queues/queue.ts
+++ b/src/main/ingestion-queues/queue.ts
@@ -2,17 +2,11 @@ import Piscina from '@posthog/piscina'
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 
-import { IngestEventResponse, PluginsServer, Queue } from '../../types'
+import { PluginsServer, Queue, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
 import { sanitizeEvent, UUIDT } from '../../utils/utils'
 import { CeleryQueue } from './celery-queue'
 import { KafkaQueue } from './kafka-queue'
-
-export type WorkerMethods = {
-    processEvent: (event: PluginEvent) => Promise<PluginEvent | null>
-    processEventBatch: (event: PluginEvent[]) => Promise<(PluginEvent | null)[]>
-    ingestEvent: (event: PluginEvent) => Promise<IngestEventResponse>
-}
 
 export function pauseQueueIfWorkerFull(
     pause: undefined | (() => void | Promise<void>),
@@ -30,6 +24,16 @@ export async function startQueue(
     workerMethods: Partial<WorkerMethods> = {}
 ): Promise<Queue> {
     const mergedWorkerMethods = {
+        onEvent: (event: PluginEvent) => {
+            server.lastActivity = new Date().valueOf()
+            server.lastActivityType = 'onEvent'
+            return piscina.runTask({ task: 'onEvent', args: { event } })
+        },
+        onSnapshot: (event: PluginEvent) => {
+            server.lastActivity = new Date().valueOf()
+            server.lastActivityType = 'onSnapshot'
+            return piscina.runTask({ task: 'onSnapshot', args: { event } })
+        },
         processEvent: (event: PluginEvent) => {
             server.lastActivity = new Date().valueOf()
             server.lastActivityType = 'processEvent'
@@ -86,10 +90,19 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
             } as PluginEvent)
             try {
                 pauseQueueIfWorkerFull(() => celeryQueue.pause(), server, piscina)
-                const processedEvent = await workerMethods.processEvent(event)
+
+                // do not run processEvent on snapshots
+                const processedEvent = event.event === '$snapshot' ? event : await workerMethods.processEvent(event)
+
                 if (processedEvent) {
                     pauseQueueIfWorkerFull(() => celeryQueue.pause(), server, piscina)
-                    await workerMethods.ingestEvent(processedEvent)
+
+                    await Promise.all([
+                        workerMethods.ingestEvent(processedEvent),
+                        processedEvent.event === '$snapshot'
+                            ? workerMethods.onSnapshot(processedEvent)
+                            : workerMethods.onEvent(processedEvent),
+                    ])
                 }
             } catch (e) {
                 Sentry.captureException(e)
@@ -104,12 +117,7 @@ function startQueueRedis(server: PluginsServer, piscina: Piscina | undefined, wo
 }
 
 async function startQueueKafka(server: PluginsServer, piscina: Piscina, workerMethods: WorkerMethods): Promise<Queue> {
-    const kafkaQueue: Queue = new KafkaQueue(
-        server,
-        piscina,
-        (event: PluginEvent) => workerMethods.processEvent(event),
-        async (event) => void (await workerMethods.ingestEvent(event))
-    )
+    const kafkaQueue: Queue = new KafkaQueue(server, piscina, workerMethods)
     await kafkaQueue.start()
 
     return kafkaQueue

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,14 @@ export interface PluginTask {
     exec: (payload?: Record<string, any>) => Promise<any>
 }
 
+export type WorkerMethods = {
+    onEvent: (event: PluginEvent) => Promise<void>
+    onSnapshot: (event: PluginEvent) => Promise<void>
+    processEvent: (event: PluginEvent) => Promise<PluginEvent | null>
+    processEventBatch: (batch: PluginEvent[]) => Promise<(PluginEvent | null)[]>
+    ingestEvent: (event: PluginEvent) => Promise<IngestEventResponse>
+}
+
 export interface PluginConfigVMReponse {
     vm: VM
     methods: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,7 +244,10 @@ export interface PluginConfigVMReponse {
     methods: {
         setupPlugin: () => Promise<void>
         teardownPlugin: () => Promise<void>
+        onEvent: (event: PluginEvent) => Promise<void>
+        onSnapshot: (event: PluginEvent) => Promise<void>
         processEvent: (event: PluginEvent) => Promise<PluginEvent>
+        // DEPRECATED
         processEventBatch: (batch: PluginEvent[]) => Promise<PluginEvent[]>
     }
     tasks: Record<PluginTaskType, Record<string, PluginTask>>

--- a/src/worker/plugins/run.ts
+++ b/src/worker/plugins/run.ts
@@ -3,7 +3,47 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { PluginConfig, PluginsServer, PluginTaskType } from '../../types'
 import { processError } from '../../utils/db/error'
 
-export async function runPlugins(server: PluginsServer, event: PluginEvent): Promise<PluginEvent | null> {
+export async function runOnEvent(server: PluginsServer, event: PluginEvent): Promise<void> {
+    const pluginsToRun = getPluginsForTeam(server, event.team_id)
+
+    await Promise.all(
+        pluginsToRun.map(async (pluginConfig) => {
+            const onEvent = await pluginConfig.vm?.getOnEvent()
+            if (onEvent) {
+                const timer = new Date()
+                try {
+                    await onEvent(event)
+                } catch (error) {
+                    await processError(server, pluginConfig, error, event)
+                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_event.ERROR`)
+                }
+                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_event`, timer)
+            }
+        })
+    )
+}
+
+export async function runOnSnapshot(server: PluginsServer, event: PluginEvent): Promise<void> {
+    const pluginsToRun = getPluginsForTeam(server, event.team_id)
+
+    await Promise.all(
+        pluginsToRun.map(async (pluginConfig) => {
+            const onSnapshot = await pluginConfig.vm?.getOnEvent()
+            if (onSnapshot) {
+                const timer = new Date()
+                try {
+                    await onSnapshot(event)
+                } catch (error) {
+                    await processError(server, pluginConfig, error, event)
+                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_event.ERROR`)
+                }
+                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_event`, timer)
+            }
+        })
+    )
+}
+
+export async function runProcessEvent(server: PluginsServer, event: PluginEvent): Promise<PluginEvent | null> {
     const pluginsToRun = getPluginsForTeam(server, event.team_id)
     let returnedEvent: PluginEvent | null = event
 
@@ -42,7 +82,7 @@ export async function runPlugins(server: PluginsServer, event: PluginEvent): Pro
     return returnedEvent
 }
 
-export async function runPluginsOnBatch(server: PluginsServer, batch: PluginEvent[]): Promise<PluginEvent[]> {
+export async function runProcessEventBatch(server: PluginsServer, batch: PluginEvent[]): Promise<PluginEvent[]> {
     const eventsByTeam = new Map<number, PluginEvent[]>()
 
     for (const event of batch) {

--- a/src/worker/plugins/run.ts
+++ b/src/worker/plugins/run.ts
@@ -28,7 +28,7 @@ export async function runOnSnapshot(server: PluginsServer, event: PluginEvent): 
 
     await Promise.all(
         pluginsToRun.map(async (pluginConfig) => {
-            const onSnapshot = await pluginConfig.vm?.getOnEvent()
+            const onSnapshot = await pluginConfig.vm?.getOnSnapshot()
             if (onSnapshot) {
                 const timer = new Date()
                 try {

--- a/src/worker/tasks.ts
+++ b/src/worker/tasks.ts
@@ -2,7 +2,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
 import { EnqueuedJob, PluginsServer, PluginTaskType } from '../types'
 import { ingestEvent } from './ingestion/ingest-event'
-import { runPlugins, runPluginsOnBatch, runPluginTask } from './plugins/run'
+import { runOnEvent, runOnSnapshot, runPluginTask, runProcessEvent, runProcessEventBatch } from './plugins/run'
 import { loadSchedule, setupPlugins } from './plugins/setup'
 import { teardownPlugins } from './plugins/teardown'
 
@@ -12,11 +12,17 @@ export const workerTasks: Record<string, TaskRunner> = {
     hello: (server, args) => {
         return `hello ${args}!`
     },
+    onEvent: (server, args: { event: PluginEvent }) => {
+        return runOnEvent(server, args.event)
+    },
+    onSnapshot: (server, args: { event: PluginEvent }) => {
+        return runOnSnapshot(server, args.event)
+    },
     processEvent: (server, args: { event: PluginEvent }) => {
-        return runPlugins(server, args.event)
+        return runProcessEvent(server, args.event)
     },
     processEventBatch: (server, args: { batch: PluginEvent[] }) => {
-        return runPluginsOnBatch(server, args.batch)
+        return runProcessEventBatch(server, args.batch)
     },
     runJob: (server, { job }: { job: EnqueuedJob }) => {
         return runPluginTask(server, job.type, PluginTaskType.Job, job.pluginConfigId, job.payload)

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -59,6 +59,14 @@ export class LazyPluginVM {
         })
     }
 
+    async getOnEvent(): Promise<PluginConfigVMReponse['methods']['onEvent'] | null> {
+        return (await this.resolveInternalVm)?.methods.onEvent || null
+    }
+
+    async getOnSnapshot(): Promise<PluginConfigVMReponse['methods']['onSnapshot'] | null> {
+        return (await this.resolveInternalVm)?.methods.onSnapshot || null
+    }
+
     async getProcessEvent(): Promise<PluginConfigVMReponse['methods']['processEvent'] | null> {
         return (await this.resolveInternalVm)?.methods.processEvent || null
     }

--- a/src/worker/vm/vm.ts
+++ b/src/worker/vm/vm.ts
@@ -152,6 +152,8 @@ export async function createPluginConfigVM(
             const __methods = {
                 setupPlugin: __asyncFunctionGuard(__bindMeta('setupPlugin')),
                 teardownPlugin: __asyncFunctionGuard(__bindMeta('teardownPlugin')),
+                onEvent: __asyncFunctionGuard(__bindMeta('onEvent')),
+                onSnapshot: __asyncFunctionGuard(__bindMeta('onSnapshot')),
                 processEvent: __asyncFunctionGuard(__bindMeta('processEvent')),
                 processEventBatch: __asyncFunctionGuard(__bindMeta('processEventBatch')),
             };

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -2,14 +2,17 @@ import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../src/config/kafka-topics'
 import { startPluginsServer } from '../../src/main/pluginsServer'
 import { LogLevel, PluginsServerConfig } from '../../src/types'
 import { PluginsServer } from '../../src/types'
-import { UUIDT } from '../../src/utils/utils'
+import { delay, UUIDT } from '../../src/utils/utils'
 import { makePiscina } from '../../src/worker/piscina'
 import { createPosthog, DummyPostHog } from '../../src/worker/vm/extensions/posthog'
+import { imports } from '../../src/worker/vm/imports'
 import { resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetKafka } from '../helpers/kafka'
 import { pluginConfig39 } from '../helpers/plugins'
 import { resetTestDatabase } from '../helpers/sql'
 import { delayUntilEventIngested } from '../shared/process-event'
+
+const { console: testConsole } = imports['test-utils/write-to-file']
 
 jest.setTimeout(60000) // 60 sec timeout
 
@@ -21,6 +24,7 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
     LOG_LEVEL: LogLevel.Log,
 }
 
+// TODO: merge these tests with postgres/e2e.test.ts
 describe('e2e clickhouse ingestion', () => {
     let server: PluginsServer
     let stopServer: () => Promise<void>
@@ -32,11 +36,20 @@ describe('e2e clickhouse ingestion', () => {
 
     beforeEach(async () => {
         await resetTestDatabase(`
-            async function processEvent (event) {
+            import { console as testConsole } from 'test-utils/write-to-file'
+            export async function processEvent (event) {
+                testConsole.log('processEvent')
                 console.info('amogus')
                 event.properties.processed = 'hell yes'
                 event.properties.upperUuid = event.properties.uuid?.toUpperCase()
+                event.properties['$snapshot_data'] = 'no way'
                 return event
+            }
+            export function onEvent (event) {
+                testConsole.log('onEvent', event.event)
+            }
+            export function onSnapshot (event) {
+                testConsole.log('onSnapshot', event.event)
             }
         `)
         await resetTestDatabaseClickhouse(extraServerConfig)
@@ -57,14 +70,42 @@ describe('e2e clickhouse ingestion', () => {
 
         posthog.capture('custom event', { name: 'haha', uuid })
 
-        await server.kafkaProducer?.flush()
         await delayUntilEventIngested(() => server.db.fetchEvents())
 
+        await server.kafkaProducer?.flush()
         const events = await server.db.fetchEvents()
+        await delay(1000)
 
         expect(events.length).toBe(1)
+
+        // processEvent ran and modified
         expect(events[0].properties.processed).toEqual('hell yes')
         expect(events[0].properties.upperUuid).toEqual(uuid.toUpperCase())
+
+        // onEvent ran
+        expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event']])
+    })
+
+    test('snapshot captured, processed, ingested', async () => {
+        expect((await server.db.fetchSessionRecordingEvents()).length).toBe(0)
+
+        const uuid = new UUIDT().toString()
+
+        posthog.capture('$snapshot', { $session_id: '1234abc', $snapshot_data: 'yes way' })
+
+        await delayUntilEventIngested(() => server.db.fetchSessionRecordingEvents())
+
+        await server.kafkaProducer?.flush()
+        const events = await server.db.fetchSessionRecordingEvents()
+        await delay(1000)
+
+        expect(events.length).toBe(1)
+
+        // processEvent did not modify
+        expect(events[0].snapshot_data).toEqual('yes way')
+
+        // onSnapshot ran
+        expect(testConsole.read()).toEqual([['onSnapshot', '$snapshot']])
     })
 
     test('console logging is persistent', async () => {

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -35,6 +35,7 @@ describe('e2e clickhouse ingestion', () => {
     })
 
     beforeEach(async () => {
+        testConsole.reset()
         await resetTestDatabase(`
             import { console as testConsole } from 'test-utils/write-to-file'
             export async function processEvent (event) {

--- a/tests/postgres/e2e.test.ts
+++ b/tests/postgres/e2e.test.ts
@@ -16,6 +16,7 @@ const { console: testConsole } = imports['test-utils/write-to-file']
 jest.mock('../../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
 
+// TODO: merge these tests with clickhouse/e2e.test.ts
 describe('e2e postgres ingestion', () => {
     let server: PluginsServer
     let stopServer: () => Promise<void>

--- a/tests/postgres/e2e.test.ts
+++ b/tests/postgres/e2e.test.ts
@@ -3,12 +3,15 @@ import * as IORedis from 'ioredis'
 import { startPluginsServer } from '../../src/main/pluginsServer'
 import { LogLevel } from '../../src/types'
 import { PluginsServer } from '../../src/types'
-import { UUIDT } from '../../src/utils/utils'
+import { delay, UUIDT } from '../../src/utils/utils'
 import { makePiscina } from '../../src/worker/piscina'
 import { createPosthog, DummyPostHog } from '../../src/worker/vm/extensions/posthog'
+import { imports } from '../../src/worker/vm/imports'
 import { pluginConfig39 } from '../helpers/plugins'
 import { resetTestDatabase } from '../helpers/sql'
 import { delayUntilEventIngested } from '../shared/process-event'
+
+const { console: testConsole } = imports['test-utils/write-to-file']
 
 jest.mock('../../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
@@ -20,14 +23,24 @@ describe('e2e postgres ingestion', () => {
     let redis: IORedis.Redis
 
     beforeEach(async () => {
+        testConsole.reset()
         console.debug = jest.fn()
 
         await resetTestDatabase(`
-            async function processEvent (event) {
+            import { console as testConsole } from 'test-utils/write-to-file'
+            export async function processEvent (event) {
+                testConsole.log('processEvent')
                 console.info('amogus')
                 event.properties.processed = 'hell yes'
                 event.properties.upperUuid = event.properties.uuid?.toUpperCase()
+                event.properties['$snapshot_data'] = 'no way'
                 return event
+            }
+            export function onEvent (event) {
+                testConsole.log('onEvent', event.event)
+            }
+            export function onSnapshot (event) {
+                testConsole.log('onSnapshot', event.event)
             }
         `)
         const startResponse = await startPluginsServer(
@@ -65,10 +78,37 @@ describe('e2e postgres ingestion', () => {
         await delayUntilEventIngested(() => server.db.fetchEvents())
 
         const events = await server.db.fetchEvents()
+        await delay(1000)
 
         expect(events.length).toBe(1)
+
+        // processEvent ran and modified
         expect(events[0].properties.processed).toEqual('hell yes')
         expect(events[0].properties.upperUuid).toEqual(uuid.toUpperCase())
+
+        // onEvent ran
+        expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event']])
+    })
+
+    test('snapshot captured, processed, ingested', async () => {
+        expect((await server.db.fetchSessionRecordingEvents()).length).toBe(0)
+
+        const uuid = new UUIDT().toString()
+
+        posthog.capture('$snapshot', { $session_id: '1234abc', $snapshot_data: 'yes way' })
+
+        await delayUntilEventIngested(() => server.db.fetchSessionRecordingEvents())
+
+        const events = await server.db.fetchSessionRecordingEvents()
+        await delay(1000)
+
+        expect(events.length).toBe(1)
+
+        // processEvent did not modify
+        expect(events[0].snapshot_data).toEqual('yes way')
+
+        // onSnapshot ran
+        expect(testConsole.read()).toEqual([['onSnapshot', '$snapshot']])
     })
 
     test('console logging is persistent', async () => {

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -4,7 +4,7 @@ import { LogLevel, PluginsServer } from '../../src/types'
 import { Client } from '../../src/utils/celery/client'
 import { createServer } from '../../src/utils/db/server'
 import { delay } from '../../src/utils/utils'
-import { runPlugins } from '../../src/worker/plugins/run'
+import { runProcessEvent } from '../../src/worker/plugins/run'
 
 jest.setTimeout(60000) // 60 sec timeout
 
@@ -62,8 +62,8 @@ test('pause and resume queue', async () => {
     expect(await redis.llen(server.PLUGINS_CELERY_QUEUE)).toBe(6)
     const piscina = setupPiscina(2, 2)
     const queue = await startQueue(server, piscina, {
-        processEvent: (event) => runPlugins(server, event),
-        processEventBatch: (events) => Promise.all(events.map((event) => runPlugins(server, event))),
+        processEvent: (event) => runProcessEvent(server, event),
+        processEventBatch: (events) => Promise.all(events.map((event) => runProcessEvent(server, event))),
         ingestEvent: () => Promise.resolve({ success: true }),
     })
     await advanceOneTick()

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -874,3 +874,35 @@ test('posthog.capture accepts user-defined distinct id', async () => {
         mockSendTask.mock.calls[0][1][6],
     ])
 })
+
+test('onEvent', async () => {
+    const indexJs = `
+        async function onEvent (event, meta) {
+            await fetch('https://google.com/results.json?query=' + event.event)
+        }
+    `
+    await resetTestDatabase(indexJs)
+    const vm = await createPluginConfigVM(mockServer, pluginConfig39, indexJs)
+    const event: PluginEvent = {
+        ...defaultEvent,
+        event: 'onEvent',
+    }
+    await vm.methods.onEvent(event)
+    expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=onEvent')
+})
+
+test('onSnapshot', async () => {
+    const indexJs = `
+        async function onSnapshot (event, meta) {
+            await fetch('https://google.com/results.json?query=' + event.event)
+        }
+    `
+    await resetTestDatabase(indexJs)
+    const vm = await createPluginConfigVM(mockServer, pluginConfig39, indexJs)
+    const event: PluginEvent = {
+        ...defaultEvent,
+        event: '$snapshot',
+    }
+    await vm.methods.onSnapshot(event)
+    expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=$snapshot')
+})

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -39,6 +39,8 @@ test('empty plugins', async () => {
 
     expect(Object.keys(vm).sort()).toEqual(['methods', 'tasks', 'vm'])
     expect(Object.keys(vm.methods).sort()).toEqual([
+        'onEvent',
+        'onSnapshot',
         'processEvent',
         'processEventBatch',
         'setupPlugin',

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -9,7 +9,7 @@ import { Client } from '../../src/utils/celery/client'
 import { delay, UUIDT } from '../../src/utils/utils'
 import { ingestEvent } from '../../src/worker/ingestion/ingest-event'
 import { makePiscina } from '../../src/worker/piscina'
-import { runPlugins, runPluginsOnBatch, runPluginTask } from '../../src/worker/plugins/run'
+import { runPluginTask, runProcessEvent, runProcessEventBatch } from '../../src/worker/plugins/run'
 import { loadSchedule, setupPlugins } from '../../src/worker/plugins/setup'
 import { teardownPlugins } from '../../src/worker/plugins/teardown'
 import { createTaskRunner } from '../../src/worker/worker'
@@ -241,21 +241,23 @@ describe('createTaskRunner()', () => {
     })
 
     it('handles `processEvent` task', async () => {
-        mocked(runPlugins).mockReturnValue('runPlugins response' as any)
+        mocked(runProcessEvent).mockReturnValue('runProcessEvent response' as any)
 
-        expect(await taskRunner({ task: 'processEvent', args: { event: 'someEvent' } })).toEqual('runPlugins response')
+        expect(await taskRunner({ task: 'processEvent', args: { event: 'someEvent' } })).toEqual(
+            'runProcessEvent response'
+        )
 
-        expect(runPlugins).toHaveBeenCalledWith(server, 'someEvent')
+        expect(runProcessEvent).toHaveBeenCalledWith(server, 'someEvent')
     })
 
     it('handles `processEventBatch` task', async () => {
-        mocked(runPluginsOnBatch).mockReturnValue(['runPluginsOnBatch response'] as any)
+        mocked(runProcessEventBatch).mockReturnValue(['runProcessEventBatch response'] as any)
 
         expect(await taskRunner({ task: 'processEventBatch', args: { batch: 'someBatch' } })).toEqual([
-            'runPluginsOnBatch response',
+            'runProcessEventBatch response',
         ])
 
-        expect(runPluginsOnBatch).toHaveBeenCalledWith(server, 'someBatch')
+        expect(runProcessEventBatch).toHaveBeenCalledWith(server, 'someBatch')
     })
 
     it('handles `getPluginSchedule` task', async () => {

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -190,7 +190,7 @@ describe('queue logic', () => {
         await delay(5000)
 
         expect(pluginsServer.piscina.queueSize).toBe(0)
-        expect(pluginsServer.piscina.completed).toBe(baseCompleted + 4)
+        expect(pluginsServer.piscina.completed).toBe(baseCompleted + 2 * 3) // 2 x (process + on + ingest)
         expect(pluginsServer.queue.isPaused()).toBe(false)
 
         // 2 tasks * 2 threads = 4 active
@@ -217,7 +217,7 @@ describe('queue logic', () => {
         expect(pausedTimes).toBeGreaterThanOrEqual(10)
         expect(pluginsServer.queue.isPaused()).toBe(false)
         expect(pluginsServer.piscina.queueSize).toBe(0)
-        expect(pluginsServer.piscina.completed).toEqual(baseCompleted + 104)
+        expect(pluginsServer.piscina.completed).toEqual(baseCompleted + 156)
 
         const duration = pluginsServer.piscina.duration - startTime
         const expectedTimeMs = (50 / 4) * 1000


### PR DESCRIPTION
## Changes

- Adds `onSnapshot`  and `onEvent` that get run for snapshots and everything else respectively
- Removes snapshots from processEvent
- Closes #328 
- Closes #280 

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
