### PR TITLE
Enable Graphile as the default job queue

### DIFF
--- a/benchmarks/vm/memory.benchmark.ts
+++ b/benchmarks/vm/memory.benchmark.ts
@@ -32,6 +32,7 @@ const mockPlugin: Plugin = {
     archive: null,
     error: undefined,
     is_global: false,
+    is_preinstalled: false,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -61,6 +61,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PLUGIN_SERVER_IDLE: false,
         JOB_QUEUES: 'graphile',
         JOB_QUEUE_GRAPHILE_URL: '',
+        JOB_QUEUE_GRAPHILE_SCHEMA: 'graphile_worker',
         CRASH_IF_NO_PERSISTENT_JOB_QUEUE: false,
         STALENESS_RESTART_SECONDS: 0,
     }
@@ -106,6 +107,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         PLUGIN_SERVER_IDLE: 'whether to disengage the plugin server, e.g. for development',
         JOB_QUEUES: 'retry queue engine and fallback queues',
         JOB_QUEUE_GRAPHILE_URL: 'use a different postgres connection in the graphile retry queue',
+        JOB_QUEUE_GRAPHILE_SCHEMA: 'the postgres schema that the graphile job queue uses',
         CRASH_IF_NO_PERSISTENT_JOB_QUEUE:
             'refuse to start unless there is a properly configured persistent job queue (e.g. graphile)',
         STALENESS_RESTART_SECONDS: 'trigger a restart if no event ingested for this duration',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -59,7 +59,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         DISTINCT_ID_LRU_SIZE: 10000,
         INTERNAL_MMDB_SERVER_PORT: 0,
         PLUGIN_SERVER_IDLE: false,
-        JOB_QUEUES: '',
+        JOB_QUEUES: 'graphile',
         JOB_QUEUE_GRAPHILE_URL: '',
         CRASH_IF_NO_PERSISTENT_JOB_QUEUE: false,
         STALENESS_RESTART_SECONDS: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,13 +43,23 @@ switch (alternativeMode) {
         }, 30_000)
         break
     case AlternativeMode.Migrate:
+        const isGraphileEnabled = defaultConfig.JOB_QUEUES.split(',')
+            .map((s) => s.trim())
+            .includes('graphile')
+
+        if (!isGraphileEnabled) {
+            status.info('😔', 'Graphile job queues not enabled. Nothing to migrate.')
+            process.exit(0)
+        }
+
         initApp(defaultConfig)
-        status.info(`🔨`, `Attemting to connect to graphile worker to run migrations`)
+
+        status.info(`🔗`, `Attempting to connect to Graphile job queue to run migrations`)
         void (async function () {
             try {
                 const graphile = new GraphileQueue(defaultConfig)
                 await graphile.migrate()
-                status.info(`🔨`, `Graphile migrations are now up to date!`)
+                status.info(`✅`, `Graphile migrations are now up to date!`)
                 await graphile.disconnectProducer()
                 process.exit(0)
             } catch (error) {

--- a/src/main/job-queues/graphile-queue.ts
+++ b/src/main/job-queues/graphile-queue.ts
@@ -2,12 +2,12 @@ import * as Sentry from '@sentry/node'
 import { makeWorkerUtils, run, Runner, WorkerUtils, WorkerUtilsOptions } from 'graphile-worker'
 import { Pool } from 'pg'
 
-import { EnqueuedJob, JobQueue, OnJobCallback, PluginsServer } from '../../types'
+import { EnqueuedJob, JobQueue, OnJobCallback, PluginsServerConfig } from '../../types'
 import { status } from '../../utils/status'
 import { createPostgresPool } from '../../utils/utils'
 
 export class GraphileQueue implements JobQueue {
-    pluginsServer: PluginsServer
+    serverConfig: PluginsServerConfig
     started: boolean
     paused: boolean
     onJob: OnJobCallback | null
@@ -16,8 +16,8 @@ export class GraphileQueue implements JobQueue {
     producerPool: Pool | null
     workerUtilsPromise: Promise<WorkerUtils> | null
 
-    constructor(pluginsServer: PluginsServer) {
-        this.pluginsServer = pluginsServer
+    constructor(serverConfig: PluginsServerConfig) {
+        this.serverConfig = serverConfig
         this.started = false
         this.paused = false
         this.onJob = null
@@ -29,9 +29,12 @@ export class GraphileQueue implements JobQueue {
 
     // producer
 
-    async connectProducer(): Promise<void> {
-        this.producerPool = await this.createPool()
+    public async migrate(): Promise<void> {
         await (await this.getWorkerUtils()).migrate()
+    }
+
+    async connectProducer(): Promise<void> {
+        await this.migrate()
     }
 
     async enqueue(retry: EnqueuedJob): Promise<void> {
@@ -43,6 +46,9 @@ export class GraphileQueue implements JobQueue {
     }
 
     private async getWorkerUtils(): Promise<WorkerUtils> {
+        if (!this.producerPool) {
+            this.producerPool = await this.createPool()
+        }
         if (!this.workerUtilsPromise) {
             this.workerUtilsPromise = makeWorkerUtils({ pgPool: this.producerPool as any })
         }
@@ -122,9 +128,9 @@ export class GraphileQueue implements JobQueue {
     async createPool(): Promise<Pool> {
         return await new Promise(async (resolve, reject) => {
             let resolved = false
-            const configOrDatabaseUrl = this.pluginsServer.JOB_QUEUE_GRAPHILE_URL
-                ? this.pluginsServer.JOB_QUEUE_GRAPHILE_URL
-                : this.pluginsServer
+            const configOrDatabaseUrl = this.serverConfig.JOB_QUEUE_GRAPHILE_URL
+                ? this.serverConfig.JOB_QUEUE_GRAPHILE_URL
+                : this.serverConfig
             const onError = (error: Error) => {
                 if (resolved) {
                     this.onConnectionError(error)

--- a/src/main/job-queues/graphile-queue.ts
+++ b/src/main/job-queues/graphile-queue.ts
@@ -52,7 +52,7 @@ export class GraphileQueue implements JobQueue {
         if (!this.workerUtilsPromise) {
             this.workerUtilsPromise = makeWorkerUtils({
                 pgPool: this.producerPool as any,
-                schema: this.pluginsServer.JOB_QUEUE_GRAPHILE_SCHEMA,
+                schema: this.serverConfig.JOB_QUEUE_GRAPHILE_SCHEMA,
             })
         }
         return await this.workerUtilsPromise
@@ -99,7 +99,7 @@ export class GraphileQueue implements JobQueue {
                 this.runner = await run({
                     // graphile's types refer to a local node_modules version of Pool
                     pgPool: (this.consumerPool as Pool) as any,
-                    schema: this.pluginsServer.JOB_QUEUE_GRAPHILE_SCHEMA,
+                    schema: this.serverConfig.JOB_QUEUE_GRAPHILE_SCHEMA,
                     concurrency: 1,
                     // Install signal handlers for graceful shutdown on SIGINT, SIGTERM, etc
                     noHandleSignals: false,

--- a/src/main/job-queues/graphile-queue.ts
+++ b/src/main/job-queues/graphile-queue.ts
@@ -50,7 +50,10 @@ export class GraphileQueue implements JobQueue {
             this.producerPool = await this.createPool()
         }
         if (!this.workerUtilsPromise) {
-            this.workerUtilsPromise = makeWorkerUtils({ pgPool: this.producerPool as any })
+            this.workerUtilsPromise = makeWorkerUtils({
+                pgPool: this.producerPool as any,
+                schema: this.pluginsServer.JOB_QUEUE_GRAPHILE_SCHEMA,
+            })
         }
         return await this.workerUtilsPromise
     }
@@ -96,6 +99,7 @@ export class GraphileQueue implements JobQueue {
                 this.runner = await run({
                     // graphile's types refer to a local node_modules version of Pool
                     pgPool: (this.consumerPool as Pool) as any,
+                    schema: this.pluginsServer.JOB_QUEUE_GRAPHILE_SCHEMA,
                     concurrency: 1,
                     // Install signal handlers for graceful shutdown on SIGINT, SIGTERM, etc
                     noHandleSignals: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,7 @@ export interface Plugin {
     plugin_type: 'local' | 'respository' | 'custom' | 'source'
     description?: string
     is_global: boolean
+    is_preinstalled: boolean
     url?: string
     config_schema: Record<string, PluginConfigSchema> | PluginConfigSchema[]
     tag?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     PLUGIN_SERVER_IDLE: boolean
     JOB_QUEUES: string
     JOB_QUEUE_GRAPHILE_URL: string
+    JOB_QUEUE_GRAPHILE_SCHEMA: string
     CRASH_IF_NO_PERSISTENT_JOB_QUEUE: boolean
     STALENESS_RESTART_SECONDS: number
 }

--- a/tests/helpers/plugins.ts
+++ b/tests/helpers/plugins.ts
@@ -45,6 +45,7 @@ export const plugin60: Plugin = {
     from_json: false,
     from_web: false,
     is_global: false,
+    is_preinstalled: false,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
 }

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -90,6 +90,7 @@ test('getPluginRows', async () => {
             from_web: false,
             id: 60,
             is_global: false,
+            is_preinstalled: false,
             organization_id: commonOrganizationId,
             latest_tag: null,
             latest_tag_checked_at: null,


### PR DESCRIPTION
## Changes

- Since not that long ago we added job queues to the plugin server. One of them is with a tool called "[graphile/worker](https://github.com/graphile/worker)", which is a postgres-based queue. 
- I'd like to enable this queue for everyone by default in 1.25.0, so there's at least some fallback for broken events. There's also the env `JOB_QUEUE_GRAPHILE_URL` for specifying a custom database for the job queue, like we have with Aurora. If that env is blank, we use `DATABASE_URL`.
- The only issue is that graphile does its migrations after connecting. This means, everyone who's using posthog, should have their database credentials set in such a way to allow the plugin server to make migrations on their `DATABASE_URL`.

Do you think this is fine? Just in case, I added small script and now if you run the plugin server with `--migrate`, so currently as simple as `cd plugins && yarn start --migrate`, it'll apply the graphile migrations in case it's a configured job queue.

Should we add this in with the other migrations somehow? The plugin server might get more migrations eventually (not sure what and when), though I can always make it work by running migration on boot. Except if there's a connection/permission error.

Also, if graphile can't connect to the database, it might stall the plugin server a bit (timeouts, ...), but it'll then bail and start normally. That's because `CRASH_IF_NO_PERSISTENT_JOB_QUEUE` is still set to "no crash" by default.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
