### PR TITLE
Punish Plugins >:D

### DIFF
--- a/src/utils/db/sql.ts
+++ b/src/utils/db/sql.ts
@@ -3,10 +3,12 @@ import {
     PluginAttachmentDB,
     PluginConfig,
     PluginError,
+    PluginId,
     PluginLogEntrySource,
     PluginLogEntryType,
     PluginsServer,
 } from '../../types'
+import { TeamId } from './../../types'
 
 function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
     return `SELECT posthog_pluginconfig.${specificField || '*'}
@@ -69,4 +71,12 @@ export async function setError(
             pluginError.time
         )
     }
+}
+
+export async function disablePlugin(server: PluginsServer, teamId: TeamId, pluginId: PluginId): Promise<void> {
+    await server.db.postgresQuery(
+        `UPDATE posthog_pluginconfig SET enabled='f' WHERE team_id=$1 AND plugin_id=$2 AND enabled='t'`,
+        [teamId, pluginId],
+        'disablePlugin'
+    )
 }

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -8,6 +8,7 @@ import {
     PluginTaskType,
 } from '../../types'
 import { clearError, processError } from '../../utils/db/error'
+import { disablePlugin } from '../../utils/db/sql'
 import { status } from '../../utils/status'
 import { createPluginConfigVM } from './vm'
 
@@ -41,10 +42,11 @@ export class LazyPluginVM {
                         pluginConfig,
                         PluginLogEntrySource.System,
                         PluginLogEntryType.Error,
-                        `Plugin failed to load (instance ID ${server.instanceId}).`,
+                        `Plugin failed to load and was disabled (instance ID ${server.instanceId}).`,
                         server.instanceId
                     )
                     status.warn('⚠️', `Failed to load ${logInfo}`)
+                    void disablePlugin(server, pluginConfig.team_id, pluginConfig.plugin_id)
                     void processError(server, pluginConfig, error)
                     resolve(null)
                 }

--- a/tests/helpers/sqlMock.ts
+++ b/tests/helpers/sqlMock.ts
@@ -10,3 +10,4 @@ export const getPluginConfigRows = (s.getPluginConfigRows as unknown) as jest.Mo
     UnPromisify<typeof s.getPluginConfigRows>
 >
 export const setError = (s.setError as unknown) as jest.MockedFunction<UnPromisify<typeof s.setError>>
+export const disablePlugin = (s.disablePlugin as unknown) as jest.MockedFunction<UnPromisify<void>>

--- a/tests/postgres/vm.lazy.test.ts
+++ b/tests/postgres/vm.lazy.test.ts
@@ -12,6 +12,11 @@ jest.mock('../../src/utils/db/error')
 jest.mock('../../src/utils/status')
 jest.mock('../../src/utils/db/sql')
 
+const mockConfig = {
+    plugin_id: 60,
+    team_id: 2,
+}
+
 describe('LazyPluginVM', () => {
     const createVM = () => new LazyPluginVM()
     const mockServer: any = {
@@ -19,7 +24,7 @@ describe('LazyPluginVM', () => {
             createPluginLogEntry: jest.fn(),
         },
     }
-    const initializeVm = (vm: LazyPluginVM) => vm.initialize!(mockServer, { plugin_id: 60 } as any, '', 'some plugin')
+    const initializeVm = (vm: LazyPluginVM) => vm.initialize!(mockServer, mockConfig as any, '', 'some plugin')
 
     describe('VM creation succeeds', () => {
         const mockVM = {
@@ -55,9 +60,9 @@ describe('LazyPluginVM', () => {
             await vm.resolveInternalVm
 
             expect(status.info).toHaveBeenCalledWith('🔌', 'Loaded some plugin')
-            expect(clearError).toHaveBeenCalledWith(mockServer, { plugin_id: 60 })
+            expect(clearError).toHaveBeenCalledWith(mockServer, mockConfig)
             expect(mockServer.db.createPluginLogEntry).toHaveBeenCalledWith(
-                { plugin_id: 60 },
+                mockConfig,
                 PluginLogEntrySource.System,
                 PluginLogEntryType.Info,
                 expect.stringContaining('Plugin loaded'),
@@ -91,10 +96,10 @@ describe('LazyPluginVM', () => {
             } catch {}
 
             expect(status.warn).toHaveBeenCalledWith('⚠️', 'Failed to load some plugin')
-            expect(processError).toHaveBeenCalledWith(mockServer, { plugin_id: 60 }, error)
-            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 39)
+            expect(processError).toHaveBeenCalledWith(mockServer, mockConfig, error)
+            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 2, 60)
             expect(mockServer.db.createPluginLogEntry).toHaveBeenCalledWith(
-                { plugin_id: 60 },
+                mockConfig,
                 PluginLogEntrySource.System,
                 PluginLogEntryType.Error,
                 expect.stringContaining('Plugin failed to load'),


### PR DESCRIPTION
## Changes

Disables plugins that errored during setup. Addresses #279 

This is somewhat a WIP from the perspective of approach. It works, but isn't particularly sophisticated.

I guess I confused you @mariusandra on Slack because I think you had this simple approach in mind whereas I was thinking of even blocking users from re-enabling plugins we "know" are broken. Hence I was talking about hashing the content and all.

Nevertheless, this is already an improvement, and I'm putting it out to spark discussion on a few points (PRs over issues):

- Do we want a retry strategy for `setupPlugin`? How many retries?
- Do we want to allow users to re-enable plugins that failed on setup even though they haven't changed at all? i.e. prevent a user from keeping on enabling a plugin that we know will fail.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
