### PR TITLE
Use pluginConfig ID instead of team + plugin id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-server",
-    "version": "0.21.2",
+    "version": "0.21.3",
     "description": "PostHog Plugin Server",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/src/utils/db/sql.ts
+++ b/src/utils/db/sql.ts
@@ -2,8 +2,8 @@ import {
     Plugin,
     PluginAttachmentDB,
     PluginConfig,
+    PluginConfigId,
     PluginError,
-    PluginId,
     PluginLogEntrySource,
     PluginLogEntryType,
     PluginsServer,
@@ -73,10 +73,10 @@ export async function setError(
     }
 }
 
-export async function disablePlugin(server: PluginsServer, teamId: TeamId, pluginId: PluginId): Promise<void> {
+export async function disablePlugin(server: PluginsServer, pluginConfigId: PluginConfigId): Promise<void> {
     await server.db.postgresQuery(
-        `UPDATE posthog_pluginconfig SET enabled='f' WHERE team_id=$1 AND plugin_id=$2 AND enabled='t'`,
-        [teamId, pluginId],
+        `UPDATE posthog_pluginconfig SET enabled='f' WHERE id=$1 AND enabled='t'`,
+        [pluginConfigId],
         'disablePlugin'
     )
 }

--- a/src/worker/vm/lazy.ts
+++ b/src/worker/vm/lazy.ts
@@ -46,7 +46,7 @@ export class LazyPluginVM {
                         server.instanceId
                     )
                     status.warn('⚠️', `Failed to load ${logInfo}`)
-                    void disablePlugin(server, pluginConfig.team_id, pluginConfig.plugin_id)
+                    void disablePlugin(server, pluginConfig.id)
                     void processError(server, pluginConfig, error)
                     resolve(null)
                 }

--- a/tests/postgres/vm.lazy.test.ts
+++ b/tests/postgres/vm.lazy.test.ts
@@ -12,9 +12,10 @@ jest.mock('../../src/utils/db/error')
 jest.mock('../../src/utils/status')
 jest.mock('../../src/utils/db/sql')
 
-const mockConfig = {
+const x = {
     plugin_id: 60,
     team_id: 2,
+    id: 39,
 }
 
 describe('LazyPluginVM', () => {

--- a/tests/postgres/vm.lazy.test.ts
+++ b/tests/postgres/vm.lazy.test.ts
@@ -97,7 +97,7 @@ describe('LazyPluginVM', () => {
 
             expect(status.warn).toHaveBeenCalledWith('⚠️', 'Failed to load some plugin')
             expect(processError).toHaveBeenCalledWith(mockServer, mockConfig, error)
-            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 2, 60)
+            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 39)
             expect(mockServer.db.createPluginLogEntry).toHaveBeenCalledWith(
                 mockConfig,
                 PluginLogEntrySource.System,

--- a/tests/postgres/vm.lazy.test.ts
+++ b/tests/postgres/vm.lazy.test.ts
@@ -15,6 +15,7 @@ jest.mock('../../src/utils/db/sql')
 const mockConfig = {
     plugin_id: 60,
     team_id: 2,
+    id: 39,
 }
 
 describe('LazyPluginVM', () => {

--- a/tests/postgres/vm.lazy.test.ts
+++ b/tests/postgres/vm.lazy.test.ts
@@ -12,10 +12,9 @@ jest.mock('../../src/utils/db/error')
 jest.mock('../../src/utils/status')
 jest.mock('../../src/utils/db/sql')
 
-const x = {
+const mockConfig = {
     plugin_id: 60,
     team_id: 2,
-    id: 39,
 }
 
 describe('LazyPluginVM', () => {
@@ -98,7 +97,7 @@ describe('LazyPluginVM', () => {
 
             expect(status.warn).toHaveBeenCalledWith('⚠️', 'Failed to load some plugin')
             expect(processError).toHaveBeenCalledWith(mockServer, mockConfig, error)
-            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 39)
+            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 2, 60)
             expect(mockServer.db.createPluginLogEntry).toHaveBeenCalledWith(
                 mockConfig,
                 PluginLogEntrySource.System,

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -149,10 +149,10 @@ describe('disablePlugin', () => {
     test('disablePlugin query builds correctly', async () => {
         server.db.postgresQuery = jest.fn() as any
 
-        await disablePlugin(server, 2, 60)
+        await disablePlugin(server, 39)
         expect(server.db.postgresQuery).toHaveBeenCalledWith(
             `UPDATE posthog_pluginconfig SET enabled='f' WHERE team_id=$1 AND plugin_id=$2 AND enabled='t'`,
-            [2, 60],
+            [39],
             'disablePlugin'
         )
     })
@@ -162,7 +162,7 @@ describe('disablePlugin', () => {
         expect(rowsBefore[0].plugin_id).toEqual(60)
         expect(rowsBefore[0].enabled).toEqual(true)
 
-        await disablePlugin(server, 2, 60)
+        await disablePlugin(server, 39)
 
         const rowsAfter = await getPluginConfigRows(server)
         expect(rowsAfter).toEqual([])

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -152,7 +152,7 @@ describe('disablePlugin', () => {
 
         await disablePlugin(server, 39)
         expect(server.db.postgresQuery).toHaveBeenCalledWith(
-            `UPDATE posthog_pluginconfig SET enabled='f' WHERE team_id=$1 AND plugin_id=$2 AND enabled='t'`,
+            `UPDATE posthog_pluginconfig SET enabled='f' WHERE id=$1 AND enabled='t'`,
             [39],
             'disablePlugin'
         )


### PR DESCRIPTION
## Changes

Updating the disablePlugin query to use `pluginConfig.id`

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
