### PR TITLE
Delete person using insertion

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -396,6 +396,7 @@ export interface ClickHousePerson {
     team_id: number
     properties: string
     is_identified: number
+    is_deleted: number
     timestamp: string
 }
 

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -324,7 +324,7 @@ export class DB {
                                     team_id: teamId,
                                     is_identified: isIdentified,
                                     id: uuid,
-                                    deleted: 0
+                                    is_deleted: 0
                                 })
                             ),
                         },
@@ -436,7 +436,7 @@ export class DB {
                                     team_id: person.team_id,
                                     is_identified: person.is_identified,
                                     id: person.uuid,
-                                    deleted: 1
+                                    is_deleted: 1
                                 })
                             ),
                         },

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -246,9 +246,12 @@ export class DB {
     public async fetchPersons(database: Database = Database.Postgres): Promise<Person[] | ClickHousePerson[]> {
         if (database === Database.ClickHouse) {
             const query = `
-                SELECT * FROM person FINAL JOIN (
+                SELECT * FROM person
+                FINAL
+                JOIN (
                     SELECT id, max(_timestamp) as _timestamp FROM person GROUP BY team_id, id
                 ) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp
+                WHERE is_deleted = 0
             `
             return (await this.clickhouseQuery(query)).data.map((row) => {
                 const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row
@@ -324,7 +327,7 @@ export class DB {
                                     team_id: teamId,
                                     is_identified: isIdentified,
                                     id: uuid,
-                                    is_deleted: 0
+                                    is_deleted: 0,
                                 })
                             ),
                         },
@@ -399,7 +402,7 @@ export class DB {
                 return `|| CASE WHEN (COALESCE(properties->>'${sanitizedPropName}', '0')~E'^([-+])?[0-9\.]+$')
                     THEN jsonb_build_object('${sanitizedPropName}', (COALESCE(properties->>'${sanitizedPropName}','0')::numeric + $${
                     index + 1
-                })) 
+                }))
                     ELSE '{}'
                 END `
             })
@@ -423,9 +426,8 @@ export class DB {
             await client.query('DELETE FROM posthog_person WHERE id = $1', [person.id])
         })
         if (this.clickhouse) {
-
             if (this.kafkaProducer) {
-                this.kafkaProducer.queueMessage({
+                await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON,
                     messages: [
                         {
@@ -436,7 +438,7 @@ export class DB {
                                     team_id: person.team_id,
                                     is_identified: person.is_identified,
                                     id: person.uuid,
-                                    is_deleted: 1
+                                    is_deleted: 1,
                                 })
                             ),
                         },

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -72,6 +72,7 @@ describe('postgres parity', () => {
                 team_id: team.id,
                 properties: '{"userProp":"propValue"}',
                 is_identified: 1,
+                is_deleted: 0,
                 _timestamp: expect.any(String),
                 _offset: expect.any(Number),
             },
@@ -131,6 +132,7 @@ describe('postgres parity', () => {
         expect(postgresPersons[0].properties).toEqual({ replacedUserProp: 'propValue' })
 
         expect(clickHousePersons[0].is_identified).toEqual(1)
+        expect(clickHousePersons[0].is_deleted).toEqual(0)
         expect(clickHousePersons[0].properties).toEqual('{"replacedUserProp":"propValue"}')
 
         // update date and boolean to false


### PR DESCRIPTION
## Changes

_Please describe._
- as a result of this [pairing session](https://github.com/PostHog/product-internal/issues/47), we're looking to use a new `deleted` field to track deleted users (similar to how deletion everywhere else behind django is managed)
- queries will account for this and filter out deleted persons

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
