### PR TITLE
Buffer console writes every 100ms

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -462,7 +462,7 @@ export function sanitizeEvent(event: PluginEvent): PluginEvent {
 }
 
 export enum NodeEnv {
-    Development = 'dev',
+    Development = 'development',
     Production = 'prod',
     Test = 'test',
 }

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -147,7 +147,7 @@ describe('job queues', () => {
             describe('invalid host/domain', () => {
                 // This crashes the tests as well. So... it, uhm, passes :D.
                 // The crash only happens when running in Github Actions of course, so hard to debug.
-                // This mode will not be activated by default, and we will not use it on cloud (yet).
+                // This mode is not activated by default, and not used on cloud (yet?).
                 test.skip('crash', async () => {
                     const config = await initTest(
                         {

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -639,6 +639,9 @@ test('console.log', async () => {
 
     await vm.methods.processEvent!(event)
 
+    // logs are saved async every 100ms
+    await delay(200)
+
     expect(hub.db.createPluginLogEntry).toHaveBeenCalledWith(
         pluginConfig39,
         'CONSOLE',


### PR DESCRIPTION
## Changes

This is an attempt to lazily solve https://github.com/PostHog/plugin-server/issues/424 by buffering `console.log` calls to run every 100ms. My theory is that writing ASAP causes strain (wildly fluctuating usage) on the postgres connection pool, which leads to deadlocks and those errors that I'm seeing.

Prior to this PR, when I ran this plugin locally:

```ts
export const jobs = {
    processEvent (event, meta) {
        console.log('retrying job!')
    }
}
export function processEvent (event, { jobs }) {
    console.log('in processEvent')
    jobs.processEvent(event).runIn(3, 'seconds')
    return event
}
```

... and browsed around app locally, I saw these timeouts in my console. 

After the changes in this PR I at first thought the timeouts got better, but not really. Soon after this happened:

```
[worker(worker-304ea0492a41cf15ba)] INFO: Completed task 928 (pluginJob) with success (0.43ms)
[worker(worker-0014bf26d851335d6e)] INFO: Completed task 929 (pluginJob) with success (0.47ms)
[MAIN] 12:02:05 🕒 Processed 5 events in 12s
[MAIN] 12:03:39 🕒 Processed 4 events in 94.43s
⌛⌛⌛ Postgres slow query warning after 30 sec {
  queryTextOrConfig: 'INSERT INTO posthog_pluginlogentry (id, team_id, plugin_id, plugin_config_id, timestamp, source,type, message, instance_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
  values: [
    '0179a81f-96e3-0000-3ac2-10e5c14925ad',
    1,
    3,
    10,
    '2021-05-26 10:01:53.123',
    'CONSOLE',
    'LOG',
    'retrying job!',
    '0179a81e-acb0-0000-9cb6-8e9003fb7044'
  ]
}
⌛⌛⌛ Postgres slow query warning after 30 sec {
  queryTextOrConfig: 'INSERT INTO posthog_pluginlogentry (id, team_id, plugin_id, plugin_config_id, timestamp, source,type, message, instance_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
  values: [
    '0179a81f-96e4-0000-cfe1-43b1c779d85c',
    1,
    3,
    10,
    '2021-05-26 10:01:53.124',
    'CONSOLE',
    'LOG',
    'retrying job!',
    '0179a81e-acb0-0000-9cb6-8e9003fb7044'
  ]
}
[worker(worker-6dd44ed891298975a3)] INFO: Completed task 932 (pluginJob) with success (0.81ms)
[worker(worker-c97bc884304d2e01cd)] INFO: Completed task 930 (pluginJob) with success (0.57ms)
[worker(worker-0014bf26d851335d6e)] INFO: Completed task 931 (pluginJob) with success (0.50ms)
```

Going to leave this PR up regardless to discuss what to do. This might be a undiagnosed problem in production as well, so we should treat it seriously :).


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
