### PR TITLE
Support Postgres environment variables for SSL configuration

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 
-import { LogLevel, PluginsServerConfig } from '../types'
+import { LogLevel, PluginsServerConfig, PostgresSSLMode } from '../types'
 import { stringToBoolean } from '../utils/utils'
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from './kafka-topics'
 
@@ -19,6 +19,10 @@ export function getDefaultConfig(): PluginsServerConfig {
         POSTHOG_DB_PASSWORD: '',
         POSTHOG_POSTGRES_HOST: 'localhost',
         POSTHOG_POSTGRES_PORT: 5432,
+        POSTHOG_POSTGRES_SSL_MODE: PostgresSSLMode.Disable,
+        POSTHOG_POSTGRES_CLI_SSL_CA: null,
+        POSTHOG_POSTGRES_CLI_SSL_CRT: null,
+        POSTHOG_POSTGRES_CLI_SSL_KEY: null
         CLICKHOUSE_HOST: 'localhost',
         CLICKHOUSE_DATABASE: isTestEnv ? 'posthog_test' : 'default',
         CLICKHOUSE_USER: 'default',

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,15 @@ import { UUID } from './utils/utils'
 import { EventsProcessor } from './worker/ingestion/process-event'
 import { LazyPluginVM } from './worker/vm/lazy'
 
+export enum PostgresSSLMode {
+    Disable = 'disable',
+    Allow = 'allow',
+    Prefer = 'prefer',
+    Require = 'require',
+    VerifyCA = 'verify-ca',
+    VerifyFull = 'verify-full',
+}
+
 export enum LogLevel {
     None = 'none',
     Debug = 'debug',
@@ -45,6 +54,10 @@ export interface PluginsServerConfig extends Record<string, any> {
     POSTHOG_DB_PASSWORD: string
     POSTHOG_POSTGRES_HOST: string
     POSTHOG_POSTGRES_PORT: number
+    POSTHOG_POSTGRES_SSL_MODE: PostgresSSLMode
+    POSTHOG_POSTGRES_CLI_SSL_CA: string | null
+    POSTHOG_POSTGRES_CLI_SSL_CRT: string | null
+    POSTHOG_POSTGRES_CLI_SSL_KEY: string | null
     CLICKHOUSE_HOST: string
     CLICKHOUSE_DATABASE: string
     CLICKHOUSE_USER: string

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,14 +3,16 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import AdmZip from 'adm-zip'
 import { randomBytes } from 'crypto'
+import { readFileSync } from 'fs';
 import Redis, { RedisOptions } from 'ioredis'
 import { DateTime } from 'luxon'
+import { FsQueue } from 'main/job-queues/local/fs-queue'
 import { Pool, PoolConfig } from 'pg'
 import { Readable } from 'stream'
 import * as tar from 'tar-stream'
 import * as zlib from 'zlib'
 
-import { LogLevel, Plugin, PluginConfigId, PluginsServerConfig, TimestampFormat } from '../types'
+import { LogLevel, Plugin, PluginConfigId, PluginJsonConfig, PluginsServerConfig, PostgresSSLMode, TimestampFormat } from '../types'
 import { status } from './status'
 
 /** Time until autoexit (due to error) gives up on graceful exit and kills the process right away. */
@@ -412,6 +414,24 @@ export function pluginDigest(plugin: Plugin, teamId?: number): string {
     return `plugin ${plugin.name} ID ${plugin.id} (${extras.join(' - ')})`
 }
 
+function createPostgresConfig(config: PluginsServerConfig) {
+    const ssl = config.POSTHOG_POSTGRES_SSL_MODE === PostgresSSLMode.Disable ? {} : {
+        rejectUnauthorized: false,
+        ca: config.POSTHOG_POSTGRES_CLI_SSL_CA ? readFileSync(config.POSTHOG_POSTGRES_CLI_SSL_CA).toString() : null,
+        key: config.POSTHOG_POSTGRES_CLI_SSL_KEY ? readFileSync(config.POSTHOG_POSTGRES_CLI_SSL_KEY).toString() : null,
+        cert: config.POSTHOG_POSTGRES_CLI_SSL_CRT ? readFileSync(config.POSTHOG_POSTGRES_CLI_SSL_CRT).toString() : null,
+    }
+
+    return {
+        database: config.POSTHOG_DB_NAME,
+        user: config.POSTHOG_DB_USER,
+        password: config.POSTHOG_DB_PASSWORD,
+        host: config.POSTHOG_POSTGRES_HOST,
+        port: config.POSTHOG_POSTGRES_PORT,
+        ssl
+    }
+}
+
 export function createPostgresPool(
     configOrDatabaseUrl: PluginsServerConfig | string,
     onError?: (error: Error) => any
@@ -422,13 +442,7 @@ export function createPostgresPool(
                   connectionString: configOrDatabaseUrl,
               }
             : configOrDatabaseUrl.POSTHOG_DB_NAME
-            ? {
-                  database: configOrDatabaseUrl.POSTHOG_DB_NAME,
-                  user: configOrDatabaseUrl.POSTHOG_DB_USER,
-                  password: configOrDatabaseUrl.POSTHOG_DB_PASSWORD,
-                  host: configOrDatabaseUrl.POSTHOG_POSTGRES_HOST,
-                  port: configOrDatabaseUrl.POSTHOG_POSTGRES_PORT,
-              }
+            ? createPostgresConfig(configOrDatabaseUrl)
             : {
                   connectionString: configOrDatabaseUrl.DATABASE_URL,
               }


### PR DESCRIPTION
## Changes

#2967 introduced additional environment variables to configure SSL on Postgres. The plugin-server didn't support these yet. This PR adds support for the same environment variables.

There's 1 caveat, which is that the sslmode cannot be set using the environment variable. It can only be set through the `DATABASE_URL` (https://github.com/brianc/node-postgres/pull/2345). I did implement `POSTHOG_POSTGRES_SSL_MODE` to easily detect whether to include SSL settings. I could remove this check altogether and simply always add the `ssl {}` config block but I'm unsure how the underlying TLS Socket will behave when receiving empty values.

I'll do an additional PR to the docs repo to clarify the usage of `POSTHOG_POSTGRES_SSL_MODE` properly.

I didn't run the jest tests since I couldn't get the test setup to work properly. I couldn't find any instructions on how to run the tests. Tried starting the `docker-compose.dev.yml` from the Posthog repo which failed to authenticate, then I found the `setup:test:postgres` script but that seems to depend on Postgres being installed on my local machine instead of using Docker. What's the right approach to test the plugin server? Would be a great addition to the README for other contributors. 

## Checklist

-   [X] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
