### PR TITLE
Run piscina worker in the main thread if concurrency at 1

### DIFF
--- a/src/worker/piscina.js
+++ b/src/worker/piscina.js
@@ -6,12 +6,47 @@ if (isMainThread) {
     const { createConfig } = require('./config')
     module.exports = {
         makePiscina: (serverConfig) => {
-            const piscina = new Piscina(createConfig(serverConfig, __filename))
-            piscina.on('error', (error) => {
-                Sentry.captureException(error)
-                console.error('⚠️', 'Piscina worker thread error:\n', error)
-            })
-            return piscina
+            const config = createConfig(serverConfig, __filename)
+            if (config.maxThreads === 1) {
+                const { createWorker } = require('./worker')
+                const workerPromise = createWorker(serverConfig, threadId)
+                const promises = new Set()
+                let completed = 0
+                const awaitWorker = async ({ task, args }) => await (await workerPromise)({ task, args })
+                const trackedWorker = ({ task, args }) => {
+                    const promise = awaitWorker({ task, args })
+                    promises.add(promise)
+                    promise.finally(() => {
+                        promises.delete(promise)
+                        completed++
+                    })
+                    return promise
+                }
+                return {
+                    runTask: ({ task, args }) => trackedWorker({ task, args }),
+                    broadcastTask: ({ task, args }) => trackedWorker({ task, args }),
+                    destroy: () => Promise.all(promises),
+                    on: () => undefined,
+                    options: {},
+                    queueSize: 0,
+                    threads: [true],
+                    completed: completed,
+                    waitTime: 0,
+                    runTime: 0,
+                    utilization: 0,
+                    duration: 0,
+                    isWorkerThread: true,
+                    workerData: null,
+                    version: 'test',
+                }
+            } else {
+                const piscina = new Piscina(config)
+                piscina.on('error', (error) => {
+                    Sentry.captureException(error)
+                    console.error('⚠️', 'Piscina worker thread error:\n', error)
+                })
+                return piscina
+            }
         },
     }
 } else {


### PR DESCRIPTION
## Changes

- WIP. Just an experiment in search of feedback (and of someone to push further)
- Instead of spawning a piscina worker pool, if concurrency is set to 1, just run everything in the main thread
- Currently exposes a fake piscina interface, which is not feature complete (no `TASKS_PER_WORKER` support)
- Actually makes everything work on a M1 macbook!
- This could be used to speed up and simplify tests in the future.

Where should we go with this, if anywhere?

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
