### PR TITLE
Clean up Jobqueues, minor fixes for S3 Queue

### DIFF
--- a/src/main/job-queues/job-queue-base.ts
+++ b/src/main/job-queues/job-queue-base.ts
@@ -36,9 +36,11 @@ export class JobQueueBase implements JobQueue {
     startConsumer(onJob: OnJobCallback): void
     // eslint-disable-next-line @typescript-eslint/require-await
     async startConsumer(onJob: OnJobCallback): Promise<void> {
-        this.started = true
         this.onJob = onJob
-        await this.syncState()
+        if (!this.started) {
+            this.started = true
+            await this.syncState()
+        }
     }
 
     stopConsumer(): void
@@ -62,8 +64,10 @@ export class JobQueueBase implements JobQueue {
     resumeConsumer(): void
     // eslint-disable-next-line @typescript-eslint/require-await
     async resumeConsumer(): Promise<void> {
-        this.paused = false
-        await this.syncState()
+        if (this.paused) {
+            this.paused = false
+            await this.syncState()
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -77,8 +81,8 @@ export class JobQueueBase implements JobQueue {
                 clearTimeout(this.timeout)
             }
             // eslint-disable-next-line @typescript-eslint/await-thenable
-            const hadSomething = await this.readState()
-            this.timeout = setTimeout(() => this.syncState(), hadSomething ? 0 : this.intervalSeconds * 1000)
+            await this.readState()
+            this.timeout = setTimeout(() => this.syncState(), this.intervalSeconds * 1000)
         } else {
             if (this.timeout) {
                 clearTimeout(this.timeout)

--- a/src/main/job-queues/job-queue-base.ts
+++ b/src/main/job-queues/job-queue-base.ts
@@ -81,8 +81,8 @@ export class JobQueueBase implements JobQueue {
                 clearTimeout(this.timeout)
             }
             // eslint-disable-next-line @typescript-eslint/await-thenable
-            await this.readState()
-            this.timeout = setTimeout(() => this.syncState(), this.intervalSeconds * 1000)
+            const hadSomething = await this.readState()
+            this.timeout = setTimeout(() => this.syncState(), hadSomething ? 0 : this.intervalSeconds * 1000)
         } else {
             if (this.timeout) {
                 clearTimeout(this.timeout)

--- a/src/main/job-queues/redlocked/s3-queue.ts
+++ b/src/main/job-queues/redlocked/s3-queue.ts
@@ -8,7 +8,7 @@ import { S3Wrapper } from '../../../utils/db/s3-wrapper'
 import { UUIDT } from '../../../utils/utils'
 import { JobQueueBase } from '../job-queue-base'
 
-const S3_POLL_INTERVAL = 5000
+const S3_POLL_INTERVAL = 5
 
 export class S3Queue extends JobQueueBase {
     serverConfig: PluginsServerConfig
@@ -20,6 +20,7 @@ export class S3Queue extends JobQueueBase {
         this.serverConfig = serverConfig
         this.s3Wrapper = null
         this.runner = null
+        this.intervalSeconds = S3_POLL_INTERVAL
     }
 
     // producer
@@ -49,19 +50,6 @@ export class S3Queue extends JobQueueBase {
     }
 
     // consumer
-
-    protected async syncState(): Promise<void> {
-        if (this.started && !this.paused) {
-            if (!this.runner) {
-                await this.connectS3()
-                this.runner = setTimeout(() => this.readState(), S3_POLL_INTERVAL)
-            }
-        } else {
-            if (this.runner) {
-                clearTimeout(this.runner)
-            }
-        }
-    }
 
     async readState(): Promise<boolean> {
         if (!this.s3Wrapper) {

--- a/src/main/job-queues/redlocked/s3-queue.ts
+++ b/src/main/job-queues/redlocked/s3-queue.ts
@@ -13,13 +13,11 @@ const S3_POLL_INTERVAL = 5
 export class S3Queue extends JobQueueBase {
     serverConfig: PluginsServerConfig
     s3Wrapper: S3Wrapper | null
-    runner: NodeJS.Timeout | null
 
     constructor(serverConfig: PluginsServerConfig) {
         super()
         this.serverConfig = serverConfig
         this.s3Wrapper = null
-        this.runner = null
         this.intervalSeconds = S3_POLL_INTERVAL
     }
 

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -152,8 +152,8 @@ describe('job queues', () => {
                 expect(testConsole.read()).toEqual([['processEvent'], ['reply', 'runIn']])
             })
 
-            test.only('polls for jobs in future', async () => {
-                const DELAY = 10000 // 10s
+            test('polls for jobs in future', async () => {
+                const DELAY = 3000 // 3s
 
                 // return something to be picked up after a few loops (poll interval is 100ms)
                 const now = Date.now()

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -151,6 +151,30 @@ describe('job queues', () => {
                 await waitForLogEntries(2)
                 expect(testConsole.read()).toEqual([['processEvent'], ['reply', 'runIn']])
             })
+
+            test.only('polls for jobs in future', async () => {
+                const DELAY = 10000 // 10s
+
+                // return something to be picked up after a few loops (poll interval is 100ms)
+                const now = Date.now()
+
+                const job: EnqueuedJob = {
+                    type: 'pluginJob',
+                    payload: { key: 'value' },
+                    timestamp: now + DELAY,
+                    pluginConfigId: 2,
+                    pluginConfigTeam: 3,
+                }
+
+                server.hub.jobQueueManager.enqueue(job)
+                const consumedJob: EnqueuedJob = await new Promise((resolve, reject) => {
+                    server.hub.jobQueueManager.startConsumer((consumedJob) => {
+                        resolve(consumedJob[0])
+                    })
+                })
+
+                expect(consumedJob).toEqual(job)
+            })
         })
 
         describe('connection', () => {
@@ -282,6 +306,45 @@ describe('job queues', () => {
             expect(mS3WrapperInstance.deleteObject).toBeCalledWith({
                 Bucket: 'bucket-name',
                 Key: `prefix/2020-01-01/20200101-123456.123Z-deadbeef.json.gz`,
+            })
+        })
+
+        test('polls for new jobs', async () => {
+            const DELAY = 10000 // 10s
+            // calls the right functions to read the enqueued job
+            mS3WrapperInstance.mockClear()
+
+            // return something to be picked up after a few loops (poll interval is 5s)
+            const now = Date.now()
+            const date = new Date(now + DELAY).toISOString()
+            const [day, time] = date.split('T')
+            const dayTime = `${day.split('-').join('')}-${time.split(':').join('')}`
+
+            const job: EnqueuedJob = {
+                type: 'pluginJob',
+                payload: { key: 'value' },
+                timestamp: now,
+                pluginConfigId: 2,
+                pluginConfigTeam: 3,
+            }
+
+            mS3WrapperInstance.listObjectsV2.mockReturnValue({
+                Contents: [{ Key: `prefix/${day}/${dayTime}-deadbeef.json.gz` }],
+            })
+            mS3WrapperInstance.getObject.mockReturnValueOnce({
+                Body: gzipSync(Buffer.from(JSON.stringify(job), 'utf8')),
+            })
+
+            const consumedJob: EnqueuedJob = await new Promise((resolve, reject) => {
+                hub.jobQueueManager.startConsumer((consumedJob) => {
+                    resolve(consumedJob[0])
+                })
+            })
+            expect(consumedJob).toEqual(job)
+            await delay(10)
+            expect(mS3WrapperInstance.deleteObject).toBeCalledWith({
+                Bucket: 'bucket-name',
+                Key: `prefix/${day}/${dayTime}-deadbeef.json.gz`,
             })
         })
     })


### PR DESCRIPTION
## Changes

Ensures S3 queue consumer runs.

Makes GraphileQueue adhere to JobQueueBase.

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
-   [x] Jest tests
