### PR TITLE
Build healthcheck into index.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ FROM node:14 AS runner
 WORKDIR /code/
 COPY --from=builder /code/ ./
 
-HEALTHCHECK --start-period=10s CMD [ "node", "dist/healthcheck.js" ]
+HEALTHCHECK --start-period=10s CMD [ "node", "dist/index.js", "--healthcheck" ]
 
 CMD [ "node", "dist/index.js" ]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Let's get you developing the plugin server in no time:
 
 1. Run Postgres pipeline tests with `yarn test:postgres:{1,2}`. Run ClickHouse pipeline tests with `yarn test:clickhouse:{1,2}`. Run benchmarks with `yarn benchmark`.
 
+## Alternative modes
+
+This program's main mode of operation is processing PostHog events, but there are also a few alternative utility ones.
+Each one does a single thing. They are listed in the table below, in order of precedence.
+
+| Name        | Description                                                | CLI flags         |
+| ----------- | ---------------------------------------------------------- | ----------------- |
+| Help        | Show plugin server [configuration options](#configuration) | `-h`, `--help`    |
+| Version     | Only show currently running plugin server version          | `-v`, `--version` |
+| Healthcheck | Check plugin server health and exit with 0 or 1            | `--healthcheck`   |
+| Migrate     | Migrate Graphile job queue                                 | `--migrate`       |
+| Idle        | Start server in a completely idle, non-processing mode     | `--idle`          |
+
 ## Configuration
 
 There's a multitude of settings you can use to control the plugin server. Use them as environment variables.

--- a/src/healthcheck.ts
+++ b/src/healthcheck.ts
@@ -1,16 +1,26 @@
 import { defaultConfig } from './config/config'
-import { Status } from './utils/status'
+import { status } from './utils/status'
 import { createRedis } from './utils/utils'
 
-const healthStatus = new Status('HLTH')
-
-void createRedis(defaultConfig).then(async (redis) => {
-    const ping = await redis.get('@posthog-plugin-server/ping')
-    if (ping) {
-        healthStatus.info('💚', `Redis key @posthog-plugin-server/ping found with value ${ping}`)
-        process.exit(0)
-    } else {
-        healthStatus.error('💔', 'Redis key @posthog-plugin-server/ping not found! Plugin server seems to be offline')
-        process.exit(1)
+export async function healthcheck(): Promise<boolean> {
+    const redis = await createRedis(defaultConfig)
+    try {
+        const ping = await redis.get('@posthog-plugin-server/ping')
+        if (ping) {
+            status.info('💚', `Redis key @posthog-plugin-server/ping found with value ${ping}`)
+            return true
+        } else {
+            status.error('💔', 'Redis key @posthog-plugin-server/ping not found! Plugin server seems to be offline')
+            return false
+        }
+    } catch (error) {
+        status.error('💥', 'An unexpected error occurred:', error)
+        return false
+    } finally {
+        redis.disconnect()
     }
-})
+}
+
+export async function healthcheckWithExit(): Promise<never> {
+    process.exit((await healthcheck()) ? 0 : 1)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { defaultConfig, formatConfigHelp } from './config/config'
+import { healthcheckWithExit } from './healthcheck'
 import { initApp } from './init'
 import { GraphileQueue } from './main/job-queues/concurrent/graphile-queue'
 import { startPluginsServer } from './main/pluginsServer'
@@ -11,8 +12,9 @@ const { argv } = process
 enum AlternativeMode {
     Help = 'HELP',
     Version = 'VRSN',
+    Healthcheck = 'HLTH',
     Idle = 'IDLE',
-    Migrate = 'MIGRATE',
+    Migrate = 'MGRT',
 }
 
 let alternativeMode: AlternativeMode | undefined
@@ -20,6 +22,8 @@ if (argv.includes('--help') || argv.includes('-h')) {
     alternativeMode = AlternativeMode.Help
 } else if (argv.includes('--version') || argv.includes('-v')) {
     alternativeMode = AlternativeMode.Version
+} else if (argv.includes('--healthcheck')) {
+    alternativeMode = AlternativeMode.Healthcheck
 } else if (argv.includes('--migrate')) {
     alternativeMode = AlternativeMode.Migrate
 } else if (defaultConfig.PLUGIN_SERVER_IDLE) {
@@ -35,6 +39,9 @@ switch (alternativeMode) {
         break
     case AlternativeMode.Help:
         status.info('⚙️', `Supported configuration environment variables:\n${formatConfigHelp(7)}`)
+        break
+    case AlternativeMode.Healthcheck:
+        void healthcheckWithExit()
         break
     case AlternativeMode.Idle:
         status.info('💤', `Disengaging this plugin server instance due to the PLUGIN_SERVER_IDLE env var...`)

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -228,7 +228,7 @@ export async function startPluginsServer(
     } catch (error) {
         Sentry.captureException(error)
         status.error('💥', 'Launchpad failure!', error)
-        void Sentry.flush() // flush in the background
+        void Sentry.flush().catch(() => null) // Flush Sentry in the background
         await closeJobs()
         process.exit(1)
     }


### PR DESCRIPTION
## Changes

Closes #372. This way healthcheck is ran with the same executable as the usual mode of the plugin server: `posthog-plugin-server --healtcheck`.

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
