### PR TITLE
$set precedence

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -91,10 +91,10 @@ export class EventsProcessor {
 
             const properties: Properties = data.properties ?? {}
             if (data['$set']) {
-                properties['$set'] = data['$set']
+                properties['$set'] = { ...properties['$set'], ...data['$set'] }
             }
             if (data['$set_once']) {
-                properties['$set_once'] = data['$set_once']
+                properties['$set_once'] = { ...properties['$set_once'], ...data['$set_once'] }
             }
 
             const personUuid = new UUIDT().toString()

--- a/src/worker/piscina.js
+++ b/src/worker/piscina.js
@@ -6,12 +6,47 @@ if (isMainThread) {
     const { createConfig } = require('./config')
     module.exports = {
         makePiscina: (serverConfig) => {
-            const piscina = new Piscina(createConfig(serverConfig, __filename))
-            piscina.on('error', (error) => {
-                Sentry.captureException(error)
-                console.error('⚠️', 'Piscina worker thread error:\n', error)
-            })
-            return piscina
+            const config = createConfig(serverConfig, __filename)
+            if (config.maxThreads === 1) {
+                const { createWorker } = require('./worker')
+                const workerPromise = createWorker(serverConfig, threadId)
+                const promises = new Set()
+                let completed = 0
+                const awaitWorker = async ({ task, args }) => await (await workerPromise)({ task, args })
+                const trackedWorker = ({ task, args }) => {
+                    const promise = awaitWorker({ task, args })
+                    promises.add(promise)
+                    promise.finally(() => {
+                        promises.delete(promise)
+                        completed++
+                    })
+                    return promise
+                }
+                return {
+                    runTask: ({ task, args }) => trackedWorker({ task, args }),
+                    broadcastTask: ({ task, args }) => trackedWorker({ task, args }),
+                    destroy: () => Promise.all(promises),
+                    on: () => undefined,
+                    options: {},
+                    queueSize: 0,
+                    threads: [true],
+                    completed: completed,
+                    waitTime: 0,
+                    runTime: 0,
+                    utilization: 0,
+                    duration: 0,
+                    isWorkerThread: true,
+                    workerData: null,
+                    version: 'test',
+                }
+            } else {
+                const piscina = new Piscina(config)
+                piscina.on('error', (error) => {
+                    Sentry.captureException(error)
+                    console.error('⚠️', 'Piscina worker thread error:\n', error)
+                })
+                return piscina
+            }
         },
     }
 } else {

--- a/src/worker/piscina.js
+++ b/src/worker/piscina.js
@@ -6,47 +6,12 @@ if (isMainThread) {
     const { createConfig } = require('./config')
     module.exports = {
         makePiscina: (serverConfig) => {
-            const config = createConfig(serverConfig, __filename)
-            if (config.maxThreads === 1) {
-                const { createWorker } = require('./worker')
-                const workerPromise = createWorker(serverConfig, threadId)
-                const promises = new Set()
-                let completed = 0
-                const awaitWorker = async ({ task, args }) => await (await workerPromise)({ task, args })
-                const trackedWorker = ({ task, args }) => {
-                    const promise = awaitWorker({ task, args })
-                    promises.add(promise)
-                    promise.finally(() => {
-                        promises.delete(promise)
-                        completed++
-                    })
-                    return promise
-                }
-                return {
-                    runTask: ({ task, args }) => trackedWorker({ task, args }),
-                    broadcastTask: ({ task, args }) => trackedWorker({ task, args }),
-                    destroy: () => Promise.all(promises),
-                    on: () => undefined,
-                    options: {},
-                    queueSize: 0,
-                    threads: [true],
-                    completed: completed,
-                    waitTime: 0,
-                    runTime: 0,
-                    utilization: 0,
-                    duration: 0,
-                    isWorkerThread: true,
-                    workerData: null,
-                    version: 'test',
-                }
-            } else {
-                const piscina = new Piscina(config)
-                piscina.on('error', (error) => {
-                    Sentry.captureException(error)
-                    console.error('⚠️', 'Piscina worker thread error:\n', error)
-                })
-                return piscina
-            }
+            const piscina = new Piscina(createConfig(serverConfig, __filename))
+            piscina.on('error', (error) => {
+                Sentry.captureException(error)
+                console.error('⚠️', 'Piscina worker thread error:\n', error)
+            })
+            return piscina
         },
     }
 } else {

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -1500,6 +1500,39 @@ export const createProcessEventTests = (
         expect(person2.properties).toEqual({ a_prop: 'test-1', b_prop: 'test-2b', c_prop: 'test-1' })
     })
 
+    test('$set and $set_once merge with properties', async () => {
+        await processEvent(
+            'distinct_id',
+            '',
+            '',
+            ({
+                event: 'some_event',
+                $set: { key1: 'value1', key2: 'value2' },
+                $set_once: { key1_once: 'value1', key2_once: 'value2' },
+                properties: {
+                    token: team.api_token,
+                    distinct_id: 'distinct_id',
+                    $set: { key2: 'value3', key3: 'value4' },
+                    $set_once: { key2_once: 'value3', key3_once: 'value4' },
+                },
+            } as any) as PluginEvent,
+            team.id,
+            now,
+            now,
+            new UUIDT().toString()
+        )
+
+        expect((await hub.db.fetchEvents()).length).toBe(1)
+
+        const [event] = await hub.db.fetchEvents()
+        expect(event.properties['$set']).toEqual({ key1: 'value1', key2: 'value2', key3: 'value4' })
+        expect(event.properties['$set_once']).toEqual({ key1_once: 'value1', key2_once: 'value2', key3_once: 'value4' })
+
+        const [person] = await hub.db.fetchPersons()
+        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id'])
+        expect(person.properties).toEqual({ key1: 'value1', key2: 'value2', key3: 'value4', key1_once: 'value1', key2_once: 'value2', key3_once: 'value4' })
+    })
+
     test('$increment increments numerical user properties or creates a new one', async () => {
         await createPerson(hub, team, ['distinct_id'])
 

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -1530,7 +1530,14 @@ export const createProcessEventTests = (
 
         const [person] = await hub.db.fetchPersons()
         expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['distinct_id'])
-        expect(person.properties).toEqual({ key1: 'value1', key2: 'value2', key3: 'value4', key1_once: 'value1', key2_once: 'value2', key3_once: 'value4' })
+        expect(person.properties).toEqual({
+            key1: 'value1',
+            key2: 'value2',
+            key3: 'value4',
+            key1_once: 'value1',
+            key2_once: 'value2',
+            key3_once: 'value4',
+        })
     })
 
     test('$increment increments numerical user properties or creates a new one', async () => {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/4592 , more context in the issue
- Previously if you had $set in both `event.$set` and `event.properties.$set` we would override the properties. Now we merge them.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
