### PR TITLE
Fix REST hook firing

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -499,7 +499,7 @@ export interface CohortPeople {
 
 /** Usable Hook model. */
 export interface Hook {
-    id: number
+    id: string
     team_id: number
     user_id: number
     resource_id: number | null

--- a/src/worker/ingestion/hooks.ts
+++ b/src/worker/ingestion/hooks.ts
@@ -223,7 +223,10 @@ export class HookCommander {
     }
 
     private async postRestHook(hook: Hook, event: PluginEvent, person: Person | undefined): Promise<void> {
-        const payload = { ...event, person, id: event.uuid }
+        const payload = {
+            hook: { id: hook.id, event: hook.event, target: hook.target },
+            data: { ...event, person },
+        }
         const request = await fetch(hook.target, {
             method: 'POST',
             body: JSON.stringify(payload, undefined, 4),

--- a/tests/worker/ingestion/ingest-event.test.ts
+++ b/tests/worker/ingestion/ingest-event.test.ts
@@ -62,7 +62,7 @@ describe('ingestEvent', () => {
     it('fires a REST hook', async () => {
         await hub.db.postgresQuery(`UPDATE posthog_organization SET available_features = '{"zapier"}'`, [], 'testTag')
         await insertRow(hub.db.postgres, 'ee_hook', {
-            id: 3,
+            id: 'abc',
             team_id: 2,
             user_id: commonUserId,
             resource_id: 69,
@@ -87,27 +87,34 @@ describe('ingestEvent', () => {
         await ingestEvent(hub, event)
 
         const expectedPayload = {
-            event: 'xyz',
-            properties: {
-                foo: 'bar',
+            hook: {
+                id: 'abc',
+                event: 'action_performed',
+                target: 'https://rest-hooks.example.com/',
             },
-            timestamp: expect.any(String),
-            now: expect.any(String),
-            team_id: 2,
-            distinct_id: 'abc',
-            ip: null,
-            site_url: 'https://example.com',
-            uuid: expect.any(String),
-            person: {
-                id: expect.any(Number),
-                created_at: expect.any(String),
+            data: {
+                event: 'xyz',
+                properties: {
+                    foo: 'bar',
+                },
+                timestamp: expect.any(String),
+                now: expect.any(String),
                 team_id: 2,
-                properties: {},
-                is_user_id: null,
-                is_identified: false,
+                distinct_id: 'abc',
+                ip: null,
+                site_url: 'https://example.com',
                 uuid: expect.any(String),
-                persondistinctid__team_id: 2,
-                persondistinctid__distinct_id: 'abc',
+                person: {
+                    id: expect.any(Number),
+                    created_at: expect.any(String),
+                    team_id: 2,
+                    properties: {},
+                    is_user_id: null,
+                    is_identified: false,
+                    uuid: expect.any(String),
+                    persondistinctid__team_id: 2,
+                    persondistinctid__distinct_id: 'abc',
+                },
             },
         }
 


### PR DESCRIPTION
## Changes

Turns out Zapier needs event data to be contained in a `data` property of payload JSON. This was a hassle to figure out, because their accepted format is not documented anywhere explicitly, and I had to dig into their Python library (not updated in a few years BTW) that we were using before to find out about this…

## Checklist

-   [ ] ~~Updated Settings section in README.md, if settings are affected~~
-   [x] Jest tests
