### PR TITLE
Action matching on static cohorts for CH

### DIFF
--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -569,12 +569,16 @@ export class DB {
     public async doesPersonBelongToCohort(cohortId: number, person: Person, teamId: Team['id']): Promise<boolean> {
         if (this.kafkaProducer) {
             const chResult = await this.clickhouseQuery(
-                `SELECT 1 FROM person_static_cohort WHERE team_id = ${teamId} AND cohort_id = ${cohortId} AND person_id = '${escapeClickHouseString(
-                    person.uuid
-                )}'`
+                `SELECT 1 FROM person_static_cohort
+                WHERE
+                    team_id = ${teamId}
+                    AND cohort_id = ${cohortId}
+                    AND person_id = '${escapeClickHouseString(person.uuid)}'
+                LIMIT 1`
             )
 
             if (chResult.rows > 0) {
+                // Cohort is static and our person belongs to it
                 return true
             }
         }

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -566,13 +566,25 @@ export class DB {
         return insertResult.rows[0]
     }
 
-    public async doesPersonBelongToCohort(cohortId: number, personId: Person['id']): Promise<boolean> {
-        const selectResult = await this.postgresQuery(
+    public async doesPersonBelongToCohort(cohortId: number, person: Person, teamId: Team['id']): Promise<boolean> {
+        if (this.kafkaProducer) {
+            const chResult = await this.clickhouseQuery(
+                `SELECT 1 FROM person_static_cohort WHERE team_id = ${teamId} AND cohort_id = ${cohortId} AND person_id = '${escapeClickHouseString(
+                    person.uuid
+                )}' LIMIT 1;`
+            )
+
+            if (chResult.rows > 0) {
+                return true
+            }
+        }
+
+        const psqlResult = await this.postgresQuery(
             `SELECT EXISTS (SELECT 1 FROM posthog_cohortpeople WHERE cohort_id = $1 AND person_id = $2);`,
-            [cohortId, personId],
+            [cohortId, person.id],
             'doesPersonBelongToCohort'
         )
-        return selectResult.rows[0].exists
+        return psqlResult.rows[0].exists
     }
 
     public async addPersonToCohort(cohortId: number, personId: Person['id']): Promise<CohortPeople> {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -571,7 +571,7 @@ export class DB {
             const chResult = await this.clickhouseQuery(
                 `SELECT 1 FROM person_static_cohort WHERE team_id = ${teamId} AND cohort_id = ${cohortId} AND person_id = '${escapeClickHouseString(
                     person.uuid
-                )}' LIMIT 1;`
+                )}'`
             )
 
             if (chResult.rows > 0) {

--- a/src/worker/ingestion/action-matcher.ts
+++ b/src/worker/ingestion/action-matcher.ts
@@ -9,7 +9,6 @@ import {
     Action,
     ActionStep,
     ActionStepUrlMatching,
-    ClickHousePerson,
     CohortPropertyFilter,
     Element,
     ElementPropertyFilter,

--- a/src/worker/ingestion/action-matcher.ts
+++ b/src/worker/ingestion/action-matcher.ts
@@ -9,6 +9,7 @@ import {
     Action,
     ActionStep,
     ActionStepUrlMatching,
+    ClickHousePerson,
     CohortPropertyFilter,
     Element,
     ElementPropertyFilter,
@@ -350,7 +351,7 @@ export class ActionMatcher {
         if (isNaN(cohortId)) {
             throw new Error(`Can't match against invalid cohort ID value "${filter.value}!"`)
         }
-        return await this.db.doesPersonBelongToCohort(Number(filter.value), person.id)
+        return await this.db.doesPersonBelongToCohort(Number(filter.value), person, person.team_id)
     }
 
     /**

--- a/tests/worker/ingestion/action-matcher.test.ts
+++ b/tests/worker/ingestion/action-matcher.test.ts
@@ -16,6 +16,7 @@ import { UUIDT } from '../../../src/utils/utils'
 import { ActionMatcher, castingCompare } from '../../../src/worker/ingestion/action-matcher'
 import { commonUserId } from '../../helpers/plugins'
 import { insertRow, resetTestDatabase } from '../../helpers/sql'
+import { KafkaProducerWrapper } from './../../../src/utils/db/kafka-producer-wrapper'
 
 describe('ActionMatcher', () => {
     let hub: Hub
@@ -726,15 +727,6 @@ describe('ActionMatcher', () => {
                 },
             ])
 
-            const randomPerson = await hub.db.createPerson(
-                DateTime.local(),
-                {},
-                actionDefinition.team_id,
-                null,
-                true,
-                new UUIDT().toString(),
-                ['random']
-            )
             const cohortPerson = await hub.db.createPerson(
                 DateTime.local(),
                 {},
@@ -775,6 +767,65 @@ describe('ActionMatcher', () => {
                 await actionMatcher.match(
                     eventExamplePersonUnknown,
                     await hub.db.fetchPerson(actionDefinition.team_id, eventExamplePersonUnknown.distinct_id)
+                )
+            ).toEqual([])
+        })
+
+        // Postgres static cohort people are no different from other cohorts
+        // so the test before is enough
+        // Here we just test CH
+        it('returns a match in case of a CH static cohort match', async () => {
+            const testCohortStatic = await hub.db.createCohort({
+                name: 'Test',
+                created_by_id: commonUserId,
+                team_id: 2,
+                is_static: true,
+            })
+
+            const actionDefinition: Action = await createTestAction([
+                {
+                    properties: [{ type: 'cohort', key: 'id', value: testCohortStatic.id }],
+                },
+            ])
+
+            const eventExamplePersonOk: PluginEvent = createTestEvent({
+                event: 'trigger a webhook',
+                distinct_id: 'static_cohort_person',
+            })
+
+            await hub.db.createPerson(
+                DateTime.local(),
+                {},
+                actionDefinition.team_id,
+                null,
+                true,
+                new UUIDT().toString(),
+                [eventExamplePersonOk.distinct_id]
+            )
+
+            hub.db.kafkaProducer = {} as KafkaProducerWrapper
+
+            // mocking the query to not have to create a whole kafka produce
+            // topic to insert a person into person_static_cohort
+            jest.spyOn(hub.db, 'clickhouseQuery')
+                .mockReturnValueOnce({
+                    rows: 1,
+                } as any)
+                .mockReturnValueOnce({
+                    rows: 0,
+                } as any)
+
+            expect(
+                await actionMatcher.match(
+                    eventExamplePersonOk,
+                    await hub.db.fetchPerson(actionDefinition.team_id, eventExamplePersonOk.distinct_id)
+                )
+            ).toEqual([actionDefinition])
+
+            expect(
+                await actionMatcher.match(
+                    eventExamplePersonOk,
+                    await hub.db.fetchPerson(actionDefinition.team_id, eventExamplePersonOk.distinct_id)
                 )
             ).toEqual([])
         })

--- a/tests/worker/ingestion/action-matcher.test.ts
+++ b/tests/worker/ingestion/action-matcher.test.ts
@@ -771,10 +771,8 @@ describe('ActionMatcher', () => {
             ).toEqual([])
         })
 
-        // Postgres static cohort people are no different from other cohorts
-        // so the test before is enough
-        // Here we just test CH
         it('returns a match in case of a CH static cohort match', async () => {
+            // Static cohorts are stored in their own ClickHouse table, hence this path has its own test
             const testCohortStatic = await hub.db.createCohort({
                 name: 'Test',
                 created_by_id: commonUserId,


### PR DESCRIPTION
## Changes

Closes #484 

Postgres is fine, everyone is in `posthog_cohortpeople`. But in CH we put people in `person_static_cohort`.

Given we don't know if the cohort is static or not when matching, I went the approach of just checking CH for a static cohort match, and if that's not the case, then check Postgres (where the "normal" cohorts are).

The other approach would be to check from Postgres if the cohort is static or not before hitting CH, but that'd result in more queries overall.


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
