### PR TITLE
Add lpush and lrange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-server",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "description": "PostHog Plugin Server",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@posthog/clickhouse": "^1.7.0",
         "@posthog/piscina": "^3.2.0-posthog",
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "0.10.0",
+        "@posthog/plugin-scaffold": "0.12.0",
         "@sentry/node": "^6.7.0",
         "@sentry/tracing": "^6.7.0",
         "@types/lru-cache": "^5.1.0",

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -222,8 +222,25 @@ export class DB {
             const client = await this.redisPool.acquire()
             const timeout = timeoutGuard('LPushing redis key delayed. Waiting over 30 sec to lpush key', { key })
             try {
-                const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
+                const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string | string[])
                 return await client.lpush(key, serializedValue)
+            } finally {
+                clearTimeout(timeout)
+                await this.redisPool.release(client)
+            }
+        })
+    }
+
+    public redisLRange(key: string, startIndex: number, endIndex: number): Promise<string[]> {
+        return instrumentQuery(this.statsd, 'query.redisLRange', undefined, async () => {
+            const client = await this.redisPool.acquire()
+            const timeout = timeoutGuard('LRANGE delayed. Waiting over 30 sec to perform LRANGE', {
+                key,
+                startIndex,
+                endIndex,
+            })
+            try {
+                return await client.lrange(key, startIndex, endIndex)
             } finally {
                 clearTimeout(timeout)
                 await this.redisPool.release(client)

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -248,6 +248,21 @@ export class DB {
         })
     }
 
+    public redisLLen(key: string): Promise<number> {
+        return instrumentQuery(this.statsd, 'query.redisLLen', undefined, async () => {
+            const client = await this.redisPool.acquire()
+            const timeout = timeoutGuard('LLEN delayed. Waiting over 30 sec to perform LLEN', {
+                key,
+            })
+            try {
+                return await client.llen(key)
+            } finally {
+                clearTimeout(timeout)
+                await this.redisPool.release(client)
+            }
+        })
+    }
+
     public redisBRPop(key1: string, key2: string): Promise<[string, string]> {
         return instrumentQuery(this.statsd, 'query.redisBRPop', undefined, async () => {
             const client = await this.redisPool.acquire()

--- a/src/worker/vm/extensions/cache.ts
+++ b/src/worker/vm/extensions/cache.ts
@@ -17,5 +17,21 @@ export function createCache(server: Hub, pluginId: number, teamId: number): Cach
         expire: async function (key, ttlSeconds) {
             return await server.db.redisExpire(getKey(key), ttlSeconds)
         },
+        lpush: async function (key, elementOrArray) {
+            const isString = typeof elementOrArray === 'string'
+            if (!Array.isArray(elementOrArray) && !isString) {
+                throw new Error('cache.lpush expects a string value or an array of strings')
+            }
+            if (!isString) {
+                elementOrArray = elementOrArray.map((el) => String(el))
+            }
+            return await server.db.redisLPush(getKey(key), elementOrArray, { jsonSerialize: false })
+        },
+        lrange: async function (key, startIndex, endIndex) {
+            if (typeof startIndex !== 'number' || typeof endIndex !== 'number') {
+                throw new Error('cache.lrange expects a number for the start and end indexes')
+            }
+            return await server.db.redisLRange(getKey(key), startIndex, endIndex)
+        },
     }
 }

--- a/src/worker/vm/extensions/cache.ts
+++ b/src/worker/vm/extensions/cache.ts
@@ -1,7 +1,7 @@
 import { CacheExtension } from '@posthog/plugin-scaffold'
-import { IllegalOperationError } from 'utils/utils'
 
 import { Hub } from '../../../types'
+import { IllegalOperationError } from '../../../utils/utils'
 
 export function createCache(server: Hub, pluginId: number, teamId: number): CacheExtension {
     const getKey = (key: string) => `@plugin/${pluginId}/${typeof teamId === 'undefined' ? '@all' : teamId}/${key}`

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -564,6 +564,36 @@ test('meta.cache incr', async () => {
     expect(event.properties!['counter']).toEqual(3)
 })
 
+test('meta.cache lpush/lrange', async () => {
+    const indexJs = `
+        async function setupPlugin (meta) {
+            await meta.cache.lpush('mylist', 'a string')
+            await meta.cache.lpush('mylist', ['an', 'array'])
+
+        }
+        async function processEvent (event, meta) {
+            const mylistBefore = await meta.cache.lrange('mylist', 0, 3)
+            event.properties['mylist_before'] = mylistBefore
+            await meta.cache.expire('mylist', 0)
+            const mylistAfter = await meta.cache.lrange('mylist', 0, 3)
+            event.properties['mylist_after'] = mylistAfter
+            return event
+        }
+
+    `
+    await resetTestDatabase(indexJs)
+    const vm = await createPluginConfigVM(hub, pluginConfig39, indexJs)
+    const event: PluginEvent = {
+        ...defaultEvent,
+        event: 'original event',
+        properties: {},
+    }
+
+    await vm.methods.processEvent!(event)
+    expect(event.properties!['mylist_before']).toEqual(expect.arrayContaining(['a string', 'an', 'array']))
+    expect(event.properties!['mylist_after']).toEqual([])
+})
+
 test('console.log', async () => {
     jest.spyOn(hub.db, 'createPluginLogEntry')
 

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -564,7 +564,7 @@ test('meta.cache incr', async () => {
     expect(event.properties!['counter']).toEqual(3)
 })
 
-test('meta.cache lpush/lrange', async () => {
+test('meta.cache lpush/lrange/llen', async () => {
     const indexJs = `
         async function setupPlugin (meta) {
             await meta.cache.lpush('mylist', 'a string')
@@ -573,7 +573,9 @@ test('meta.cache lpush/lrange', async () => {
         }
         async function processEvent (event, meta) {
             const mylistBefore = await meta.cache.lrange('mylist', 0, 3)
+            const mylistLen = await meta.cache.llen('mylist')
             event.properties['mylist_before'] = mylistBefore
+            event.properties['mylist_len'] = mylistLen
             await meta.cache.expire('mylist', 0)
             const mylistAfter = await meta.cache.lrange('mylist', 0, 3)
             event.properties['mylist_after'] = mylistAfter
@@ -591,6 +593,7 @@ test('meta.cache lpush/lrange', async () => {
 
     await vm.methods.processEvent!(event)
     expect(event.properties!['mylist_before']).toEqual(expect.arrayContaining(['a string', 'an', 'array']))
+    expect(event.properties!['mylist_len']).toEqual(3)
     expect(event.properties!['mylist_after']).toEqual([])
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,10 +1729,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.10.0.tgz#e80f57c5d3833753632607bed3ca71ebf272b12b"
-  integrity sha512-c8lNzQTBMJ0X3SCjcaD+mXZIx2thc+ptf8G4gbfT9YBFFD6TMaxs+/APMUab2aRJRbVwOsCGj9poxwuF4wxPpA==
+"@posthog/plugin-scaffold@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.12.0.tgz#8653c0a75274744bf98e588581eb6d29ae842536"
+  integrity sha512-TVsciywvY2DBt81rnWNgGOTt9HgMTkcNIHco7SevKs4opGKBXjYZYiySL3IJd+MWr4v6CYfmYtyGZyf/GLJ/Zw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Changes

Adds support for Redis `LPUSH` and `LRANGE` ops via the cache extension.

I was wondering if I should add a special timeout for these operations given their nature? Or would the plugin timeouts suffice? WDYT @Twixes ?

~~plugin-scaffold PR coming~~ https://github.com/PostHog/plugin-scaffold/pull/23

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
