### PR TITLE
fix nan timestamp

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -166,7 +166,8 @@ export class EventsProcessor {
                 try {
                     // timestamp and sent_at must both be in the same format: either both with or both without timezones
                     // otherwise we can't get a diff to add to now
-                    return now.plus(DateTime.fromISO(data['timestamp']).diff(sentAt))
+                    const timestamp = new Date(data['timestamp']).toISOString()
+                    return now.plus(DateTime.fromISO(timestamp).diff(sentAt))
                 } catch (error) {
                     status.error('⚠️', 'Error when handling timestamp:', error)
                     Sentry.captureException(error, { extra: { data, now, sentAt } })

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -166,8 +166,7 @@ export class EventsProcessor {
                 try {
                     // timestamp and sent_at must both be in the same format: either both with or both without timezones
                     // otherwise we can't get a diff to add to now
-                    const timestamp = new Date(data['timestamp']).toISOString()
-                    return now.plus(DateTime.fromISO(timestamp).diff(sentAt))
+                    return now.plus(DateTime.fromJSDate(new Date(data['timestamp'])).diff(sentAt))
                 } catch (error) {
                     status.error('⚠️', 'Error when handling timestamp:', error)
                     Sentry.captureException(error, { extra: { data, now, sentAt } })


### PR DESCRIPTION
## Changes

Should solve [PLUGIN-SERVER-DN ](https://sentry.io/organizations/posthog/issues/2483414066/events/latest/?project=5592816&statsPeriod=14d). Seems for some reason we're getting timestamps in this format: 

```
MM/DD/YYYY HH:MM:SS AM|PM
```

Haven't managed to reliably pinpoint how we get here though. 

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
