### PR TITLE
`is_deleted` for `person_distinct_id`, fix a race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
+                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -253,6 +254,7 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
+                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -332,6 +334,7 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
+                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -423,6 +426,7 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
+                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
-                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -178,7 +177,6 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
-                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -254,7 +252,6 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
-                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -334,7 +331,6 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
-                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2
@@ -426,7 +422,6 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
-                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
               with:
                   repository: 'PostHog/posthog'
                   path: 'posthog/'
+                  ref: port-queries
 
             - name: Check out plugin server
               uses: actions/checkout@v2

--- a/src/types.ts
+++ b/src/types.ts
@@ -491,6 +491,7 @@ export interface ClickHousePersonDistinctId {
     team_id: number
     person_id: string
     distinct_id: string
+    sign: 1 | -1
 }
 
 /** Usable Cohort model. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -491,7 +491,7 @@ export interface ClickHousePersonDistinctId {
     team_id: number
     person_id: string
     distinct_id: string
-    sign: 1 | -1
+    is_deleted: 0 | 1
 }
 
 /** Usable Cohort model. */

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -467,7 +467,7 @@ export class DB {
 
     public async deletePerson(person: Person): Promise<void> {
         await this.postgresTransaction(async (client) => {
-            await client.query('DELETE FROM posthog_person WHERE team_id = $1 AND id = $1', [person.team_id, person.id])
+            await client.query('DELETE FROM posthog_person WHERE team_id = $1 AND id = $2', [person.team_id, person.id])
         })
         if (this.kafkaProducer) {
             await this.kafkaProducer.queueMessage({

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -550,7 +550,7 @@ export class DB {
                 messages: [
                     {
                         value: Buffer.from(
-                            JSON.stringify({ ...personDistinctIdCreated, person_id: person.uuid, sign: 1 })
+                            JSON.stringify({ ...personDistinctIdCreated, person_id: person.uuid, is_deleted: 0 })
                         ),
                     },
                 ],
@@ -575,11 +575,13 @@ export class DB {
             for (const row of movedDistinctIdResult.rows) {
                 await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON_UNIQUE_ID,
-                    messages: [{ value: Buffer.from(JSON.stringify({ ...row, person_id: target.uuid, sign: 1 })) }],
+                    messages: [
+                        { value: Buffer.from(JSON.stringify({ ...row, person_id: target.uuid, is_deleted: 0 })) },
+                    ],
                 })
                 await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON_UNIQUE_ID,
-                    messages: [{ value: Buffer.from(JSON.stringify({ ...row, sign: -1 })) }],
+                    messages: [{ value: Buffer.from(JSON.stringify({ ...row, is_deleted: 1 })) }],
                 })
             }
         }

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -504,14 +504,19 @@ export class DB {
         if (database === Database.ClickHouse) {
             return (
                 await this.clickhouseQuery(
-                    `SELECT * FROM person_distinct_id WHERE person_id='${escapeClickHouseString(
-                        person.uuid
-                    )}' and team_id='${person.team_id}' ORDER BY id`
+                    `
+                        SELECT *
+                        FROM person_distinct_id
+                        FINAL
+                        WHERE person_id='${escapeClickHouseString(person.uuid)}'
+                          AND team_id='${person.team_id}'
+                          AND is_deleted=0
+                        ORDER BY id`
                 )
             ).data as ClickHousePersonDistinctId[]
         } else if (database === Database.Postgres) {
             const result = await this.postgresQuery(
-                'SELECT * FROM posthog_persondistinctid WHERE person_id=$1 and team_id=$2 ORDER BY id',
+                'SELECT * FROM posthog_persondistinctid WHERE person_id=$1 AND team_id=$2 ORDER BY id',
                 [person.id, person.team_id],
                 'fetchDistinctIds'
             )

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -568,7 +568,6 @@ export class DB {
                 SET person_id = $1
                 WHERE person_id = $2
                   AND team_id = $3
-                ON CONFLICT DO NOTHING
                 RETURNING *
             `,
             [target.id, source.id, target.team_id],

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -581,7 +581,9 @@ export class DB {
                 })
                 await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON_UNIQUE_ID,
-                    messages: [{ value: Buffer.from(JSON.stringify({ ...row, is_deleted: 1 })) }],
+                    messages: [
+                        { value: Buffer.from(JSON.stringify({ ...row, person_id: source.uuid, is_deleted: 1 })) },
+                    ],
                 })
             }
         }

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -298,8 +298,10 @@ export class DB {
                 return rest
             }) as ClickHousePerson[]
         } else if (database === Database.Postgres) {
-            return ((await this.postgresQuery('SELECT * FROM posthog_person', undefined, 'fetchPersons'))
-                .rows as RawPerson[]).map(
+            return (
+                (await this.postgresQuery('SELECT * FROM posthog_person', undefined, 'fetchPersons'))
+                    .rows as RawPerson[]
+            ).map(
                 (rawPerson: RawPerson) =>
                     ({
                         ...rawPerson,
@@ -667,8 +669,9 @@ export class DB {
 
     public async fetchSessionRecordingEvents(): Promise<PostgresSessionRecordingEvent[] | SessionRecordingEvent[]> {
         if (this.kafkaProducer) {
-            const events = ((await this.clickhouseQuery(`SELECT * FROM session_recording_events`))
-                .data as SessionRecordingEvent[]).map((event) => {
+            const events = (
+                (await this.clickhouseQuery(`SELECT * FROM session_recording_events`)).data as SessionRecordingEvent[]
+            ).map((event) => {
                 return {
                     ...event,
                     snapshot_data: event.snapshot_data ? JSON.parse(event.snapshot_data) : null,

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -364,16 +364,8 @@ export class EventsProcessor {
         // In the rare case of the person changing VERY often however, it may happen even a few times,
         // in which case we'll bail and rethrow the error.
         while (true) {
-            const otherPersonDistinctIds: PersonDistinctId[] = (
-                await this.db.postgresQuery(
-                    'SELECT * FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2',
-                    [otherPerson.id, mergeInto.team_id],
-                    'otherPersonDistinctIds'
-                )
-            ).rows
-            for (const otherPersonDistinctId of otherPersonDistinctIds) {
-                await this.db.moveDistinctId(otherPersonDistinctId, mergeInto)
-            }
+            await this.db.moveDistinctIds(otherPerson, mergeInto)
+
             try {
                 await this.db.deletePerson(otherPerson)
                 break // All OK, exiting retry loop

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -330,66 +330,62 @@ export class EventsProcessor {
         }
 
         if (oldPerson && newPerson && oldPerson.id !== newPerson.id) {
-            await this.mergePeople(newPerson, [oldPerson])
+            await this.mergePeople(newPerson, oldPerson)
         }
     }
 
-    public async mergePeople(mergeInto: Person, peopleToMerge: Person[]): Promise<void> {
+    public async mergePeople(mergeInto: Person, otherPerson: Person): Promise<void> {
         let firstSeen = mergeInto.created_at
 
         // Merge properties
-        for (const otherPerson of peopleToMerge) {
-            mergeInto.properties = { ...otherPerson.properties, ...mergeInto.properties }
-            if (otherPerson.created_at < firstSeen) {
-                // Keep the oldest created_at (i.e. the first time we've seen this person)
-                firstSeen = otherPerson.created_at
-            }
+        mergeInto.properties = { ...otherPerson.properties, ...mergeInto.properties }
+        if (otherPerson.created_at < firstSeen) {
+            // Keep the oldest created_at (i.e. the first time we've seen this person)
+            firstSeen = otherPerson.created_at
         }
 
         await this.db.updatePerson(mergeInto, { created_at: firstSeen, properties: mergeInto.properties })
 
         // Merge the distinct IDs
-        for (const otherPerson of peopleToMerge) {
-            await this.db.postgresQuery(
-                'UPDATE posthog_cohortpeople SET person_id = $1 WHERE person_id = $2',
-                [mergeInto.id, otherPerson.id],
-                'updateCohortPeople'
-            )
-            let failedAttempts = 0
-            // Retrying merging up to `MAX_FAILED_PERSON_MERGE_ATTEMPTS` times, in case race conditions occur.
-            // An example is a distinct ID being aliased in another plugin server instance,
-            // between `moveDistinctId` and `deletePerson` being called here
-            // – in such a case a distinct ID may be assigned to the person in the database
-            // AFTER `otherPersonDistinctIds` was fetched, so this function is not aware of it and doesn't merge it.
-            // That then causeds `deletePerson` to fail, because of foreign key constraints –
-            // the dangling distinct ID added elsewhere prevents the person from being deleted!
-            // This is low-probability so likely won't occur on second retry of this block.
-            // In the rare case of the person changing VERY often however, it may happen even a few times,
-            // in which case we'll bail and rethrow the error.
-            while (true) {
-                const otherPersonDistinctIds: PersonDistinctId[] = (
-                    await this.db.postgresQuery(
-                        'SELECT * FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2',
-                        [otherPerson.id, mergeInto.team_id],
-                        'otherPersonDistinctIds'
-                    )
-                ).rows
-                for (const otherPersonDistinctId of otherPersonDistinctIds) {
-                    await this.db.moveDistinctId(otherPersonDistinctId, mergeInto)
+        await this.db.postgresQuery(
+            'UPDATE posthog_cohortpeople SET person_id = $1 WHERE person_id = $2',
+            [mergeInto.id, otherPerson.id],
+            'updateCohortPeople'
+        )
+        let failedAttempts = 0
+        // Retrying merging up to `MAX_FAILED_PERSON_MERGE_ATTEMPTS` times, in case race conditions occur.
+        // An example is a distinct ID being aliased in another plugin server instance,
+        // between `moveDistinctId` and `deletePerson` being called here
+        // – in such a case a distinct ID may be assigned to the person in the database
+        // AFTER `otherPersonDistinctIds` was fetched, so this function is not aware of it and doesn't merge it.
+        // That then causeds `deletePerson` to fail, because of foreign key constraints –
+        // the dangling distinct ID added elsewhere prevents the person from being deleted!
+        // This is low-probability so likely won't occur on second retry of this block.
+        // In the rare case of the person changing VERY often however, it may happen even a few times,
+        // in which case we'll bail and rethrow the error.
+        while (true) {
+            const otherPersonDistinctIds: PersonDistinctId[] = (
+                await this.db.postgresQuery(
+                    'SELECT * FROM posthog_persondistinctid WHERE person_id = $1 AND team_id = $2',
+                    [otherPerson.id, mergeInto.team_id],
+                    'otherPersonDistinctIds'
+                )
+            ).rows
+            for (const otherPersonDistinctId of otherPersonDistinctIds) {
+                await this.db.moveDistinctId(otherPersonDistinctId, mergeInto)
+            }
+            try {
+                await this.db.deletePerson(otherPerson)
+                break // All OK, exiting retry loop
+            } catch (error) {
+                if (!(error instanceof DatabaseError)) {
+                    throw error // Very much not OK, this is some completely unexpected error
                 }
-                try {
-                    await this.db.deletePerson(otherPerson)
-                    break // All OK, exiting retry loop
-                } catch (error) {
-                    if (!(error instanceof DatabaseError)) {
-                        throw error // Very much not OK, this is some completely unexpected error
-                    }
-                    failedAttempts++
-                    if (failedAttempts === MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
-                        throw error // Very much not OK, failed repeatedly so rethrowing the error
-                    }
-                    continue // Not OK, trying again to make sure that ALL distinct IDs are merged
+                failedAttempts++
+                if (failedAttempts === MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
+                    throw error // Very much not OK, failed repeatedly so rethrowing the error
                 }
+                continue // Not OK, trying again to make sure that ALL distinct IDs are merged
             }
         }
     }

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -14,6 +14,7 @@ import { delayUntilEventIngested } from '../shared/process-event'
 
 const { console: testConsole } = writeToFile
 
+jest.mock('../../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
 
 const extraServerConfig: Partial<PluginsServerConfig> = {

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -226,6 +226,7 @@ describe('postgres parity', () => {
                 distinct_id: 'distinct1',
                 person_id: person.uuid,
                 team_id: team.id,
+                is_deleted: 0,
                 _timestamp: expect.any(String),
                 _offset: expect.any(Number),
             },

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -228,41 +228,6 @@ describe('postgres parity', () => {
         expect(postgresDistinctIdValuesOther).toEqual(['another_distinct_id'])
     })
 
-    // test('deletePerson', async () => {
-    //     const uuid = new UUIDT().toString()
-    //     const person = await hub.db.createPerson(
-    //         DateTime.utc(),
-    //         { userProp: 'propValue' },
-    //         team.id,
-    //         null,
-    //         false,
-    //         uuid,
-    //         ['distinct1', 'distinct2']
-    //     )
-    //     await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
-    //     await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
-
-    //     await hub.db.deletePerson(person)
-
-    //     await delayUntilEventIngested(async () =>
-    //         (await hub.db.fetchPersons(Database.ClickHouse)).length === 0 ? ['deleted!'] : []
-    //     )
-    //     await delayUntilEventIngested(async () =>
-    //         (await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)).length === 0 ? ['deleted!'] : []
-    //     )
-
-    //     const clickHousePersons = await hub.db.fetchPersons(Database.ClickHouse)
-    //     const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
-
-    //     expect(clickHousePersons.length).toEqual(0)
-    //     expect(postgresPersons.length).toEqual(0)
-
-    //     const clickHouseDistinctIdValues = await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)
-    //     const postgresDistinctIdValues = await hub.db.fetchDistinctIdValues(person, Database.Postgres)
-    //     expect(clickHouseDistinctIdValues.length).toEqual(0)
-    //     expect(postgresDistinctIdValues.length).toEqual(0)
-    // })
-
     test('moveDistinctIds & deletePerson', async () => {
         const uuid = new UUIDT().toString()
         const uuid2 = new UUIDT().toString()

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -262,7 +262,7 @@ describe('postgres parity', () => {
 
         // move 'distinct1' from person to to anotherPerson
 
-        await hub.db.moveDistinctId(postgresDistinctIds[0], anotherPerson)
+        await hub.db.moveDistinctIds(person, anotherPerson)
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(anotherPerson, Database.ClickHouse), 2)
 
         // it got added

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -156,42 +156,7 @@ describe('postgres parity', () => {
         )
     })
 
-    test('deletePerson', async () => {
-        const uuid = new UUIDT().toString()
-        const person = await hub.db.createPerson(
-            DateTime.utc(),
-            { userProp: 'propValue' },
-            team.id,
-            null,
-            false,
-            uuid,
-            ['distinct1', 'distinct2']
-        )
-        await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
-        await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
-
-        await hub.db.deletePerson(person)
-
-        await delayUntilEventIngested(async () =>
-            (await hub.db.fetchPersons(Database.ClickHouse)).length === 0 ? ['deleted!'] : []
-        )
-        await delayUntilEventIngested(async () =>
-            (await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)).length === 0 ? ['deleted!'] : []
-        )
-
-        const clickHousePersons = await hub.db.fetchPersons(Database.ClickHouse)
-        const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
-
-        expect(clickHousePersons.length).toEqual(0)
-        expect(postgresPersons.length).toEqual(0)
-
-        const clickHouseDistinctIdValues = await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)
-        const postgresDistinctIdValues = await hub.db.fetchDistinctIdValues(person, Database.Postgres)
-        expect(clickHouseDistinctIdValues.length).toEqual(0)
-        expect(postgresDistinctIdValues.length).toEqual(0)
-    })
-
-    test('addDistinctId & moveDistinctId', async () => {
+    test('addDistinctId', async () => {
         const uuid = new UUIDT().toString()
         const uuid2 = new UUIDT().toString()
         const person = await hub.db.createPerson(DateTime.utc(), { userProp: 'propValue' }, team.id, null, true, uuid, [
@@ -261,8 +226,66 @@ describe('postgres parity', () => {
 
         expect(clickHouseDistinctIdValuesOther).toEqual(['another_distinct_id'])
         expect(postgresDistinctIdValuesOther).toEqual(['another_distinct_id'])
+    })
 
-        // move 'distinct1' from person to to anotherPerson
+    // test('deletePerson', async () => {
+    //     const uuid = new UUIDT().toString()
+    //     const person = await hub.db.createPerson(
+    //         DateTime.utc(),
+    //         { userProp: 'propValue' },
+    //         team.id,
+    //         null,
+    //         false,
+    //         uuid,
+    //         ['distinct1', 'distinct2']
+    //     )
+    //     await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
+    //     await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
+
+    //     await hub.db.deletePerson(person)
+
+    //     await delayUntilEventIngested(async () =>
+    //         (await hub.db.fetchPersons(Database.ClickHouse)).length === 0 ? ['deleted!'] : []
+    //     )
+    //     await delayUntilEventIngested(async () =>
+    //         (await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)).length === 0 ? ['deleted!'] : []
+    //     )
+
+    //     const clickHousePersons = await hub.db.fetchPersons(Database.ClickHouse)
+    //     const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
+
+    //     expect(clickHousePersons.length).toEqual(0)
+    //     expect(postgresPersons.length).toEqual(0)
+
+    //     const clickHouseDistinctIdValues = await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)
+    //     const postgresDistinctIdValues = await hub.db.fetchDistinctIdValues(person, Database.Postgres)
+    //     expect(clickHouseDistinctIdValues.length).toEqual(0)
+    //     expect(postgresDistinctIdValues.length).toEqual(0)
+    // })
+
+    test('moveDistinctIds & deletePerson', async () => {
+        const uuid = new UUIDT().toString()
+        const uuid2 = new UUIDT().toString()
+        const person = await hub.db.createPerson(DateTime.utc(), { userProp: 'propValue' }, team.id, null, true, uuid, [
+            'distinct1',
+        ])
+        const anotherPerson = await hub.db.createPerson(
+            DateTime.utc(),
+            { userProp: 'propValue' },
+            team.id,
+            null,
+            true,
+            uuid2,
+            ['another_distinct_id']
+        )
+        await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
+        const [postgresPerson] = await hub.db.fetchPersons(Database.Postgres)
+
+        await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(postgresPerson, Database.ClickHouse), 1)
+        const clickHouseDistinctIdValues = await hub.db.fetchDistinctIdValues(postgresPerson, Database.ClickHouse)
+        const postgresDistinctIdValues = await hub.db.fetchDistinctIdValues(postgresPerson, Database.Postgres)
+
+        // move distinct ids from person to to anotherPerson
 
         await hub.db.moveDistinctIds(person, anotherPerson)
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(anotherPerson, Database.ClickHouse), 2)
@@ -283,9 +306,25 @@ describe('postgres parity', () => {
         )
         const postgresDistinctIdValuesRemoved = await hub.db.fetchDistinctIdValues(postgresPerson, Database.Postgres)
 
-        // The `distinct1` key is still there in clickhouse, yet ALSO there for the new person.
-        // Eventually this should be compacted away but it's not right now.
-        expect(clickHouseDistinctIdValuesRemoved).toEqual(['distinct1', 'anotherOne'])
-        expect(postgresDistinctIdValuesRemoved).toEqual(['anotherOne'])
+        expect(clickHouseDistinctIdValuesRemoved).toEqual([])
+        expect(postgresDistinctIdValuesRemoved).toEqual([])
+
+        // delete person
+
+        await hub.db.deletePerson(person)
+
+        // Check distinct ids
+        await delayUntilEventIngested(async () =>
+            (await hub.db.fetchPersons(Database.ClickHouse)).length === 1 ? ['deleted!'] : []
+        )
+        await delayUntilEventIngested(async () =>
+            (await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)).length === 1 ? ['deleted!'] : []
+        )
+
+        const clickHousePersons = await hub.db.fetchPersons(Database.ClickHouse)
+        const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
+
+        expect(clickHousePersons.length).toEqual(1)
+        expect(postgresPersons.length).toEqual(1)
     })
 })

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -11,6 +11,7 @@ import { pluginConfig39 } from '../helpers/plugins'
 import { getFirstTeam, resetTestDatabase } from '../helpers/sql'
 import { delayUntilEventIngested } from '../shared/process-event'
 
+jest.mock('../../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
 
 const extraServerConfig: Partial<PluginsServerConfig> = {

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -160,6 +160,7 @@ export async function createUserTeamAndOrganization(
         setup_section_2_completed: true,
         for_internal_metrics: false,
         available_features: [],
+        domain_whitelist: [],
     } as RawOrganization)
     await insertRow(db, 'posthog_organizationmembership', {
         id: organizationMembershipId,

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -11,6 +11,7 @@ import { delay, UUIDT } from '../../src/utils/utils'
 import { EventProcessingResult, EventsProcessor } from '../../src/worker/ingestion/process-event'
 import { createUserTeamAndOrganization, getFirstTeam, getTeams, onQuery, resetTestDatabase } from '../helpers/sql'
 
+jest.mock('../../src/utils/status')
 jest.setTimeout(600000) // 600 sec timeout.
 
 export async function delayUntilEventIngested(

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -144,7 +144,7 @@ export const createProcessEventTests = (
 
         await hub.db.updatePerson(p0, { created_at: DateTime.fromISO('2020-01-01T00:00:00Z') })
 
-        const p1 = await createPerson(hub, team, ['person_1'], { $os: 'Chrome' })
+        const p1 = await createPerson(hub, team, ['person_1'], { $os: 'Chrome', $browser: 'Chrome' })
         if (database === 'clickhouse') {
             await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
         }
@@ -164,18 +164,15 @@ export const createProcessEventTests = (
             new UUIDT().toString()
         )
 
-        await createPerson(hub, team, ['person_2'], { $os: 'Apple', $browser: 'MS Edge' })
-        await createPerson(hub, team, ['person_3'], { $os: 'PlayStation' })
-
         if (database === 'clickhouse') {
-            await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 4)
-            expect((await hub.db.fetchPersons(Database.ClickHouse)).length).toEqual(4)
+            await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
+            expect((await hub.db.fetchPersons(Database.ClickHouse)).length).toEqual(2)
         }
 
-        expect((await hub.db.fetchPersons()).length).toEqual(4)
-        const [person0, person1, person2, person3] = await hub.db.fetchPersons()
+        expect((await hub.db.fetchPersons()).length).toEqual(2)
+        const [person0, person1] = await hub.db.fetchPersons()
 
-        await eventsProcessor.mergePeople(person0, [person1, person2, person3])
+        await eventsProcessor.mergePeople(person0, person1)
 
         if (database === 'clickhouse') {
             await delayUntilEventIngested(async () =>
@@ -188,8 +185,8 @@ export const createProcessEventTests = (
 
         const [person] = await hub.db.fetchPersons()
 
-        expect(person.properties).toEqual({ $os: 'Microsoft', $browser: 'MS Edge' })
-        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['person_0', 'person_1', 'person_2', 'person_3'])
+        expect(person.properties).toEqual({ $os: 'Microsoft', $browser: 'Chrome' })
+        expect(await hub.db.fetchDistinctIdValues(person)).toEqual(['person_0', 'person_1'])
         expect(person.created_at.toISO()).toEqual(DateTime.fromISO('2019-07-01T00:00:00Z').setZone('UTC').toISO())
     })
 


### PR DESCRIPTION
This PR:
- Fixes a race condition in plugin server causing wrong rows to appear in person_distinct_id table: https://github.com/PostHog/plugin-server/issues/502
- Updates ingestion to use `is_deleted` column for `person_distinct_id` table instead of deleting rows
- Fixes broken build due to new column in `organization` table

See companion PR for more context: https://github.com/PostHog/posthog/pull/5151 
Related issue: https://github.com/PostHog/posthog/issues/4242

Note that:
- Workflows got updated on the PR to point to open PR on posthog/ repo to make tests pass. Will revert just before merging

## Checklist

-   [x] Updated Settings section in README.md, if settings are affected
-   [x] Jest tests
