### PR TITLE
Import from Redshift

### DIFF
--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -186,7 +186,7 @@ export async function startPluginsServer(
             })
         }
 
-        pluginMetricsJob = schedule.scheduleJob('*/1 * * * *', async () => {
+        pluginMetricsJob = schedule.scheduleJob('*/30 * * * *', async () => {
             await piscina!.broadcastTask({ task: 'sendPluginMetrics' })
         })
 

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -186,7 +186,7 @@ export async function startPluginsServer(
             })
         }
 
-        pluginMetricsJob = schedule.scheduleJob('*/30 * * * *', async () => {
+        pluginMetricsJob = schedule.scheduleJob('*/1 * * * *', async () => {
             await piscina!.broadcastTask({ task: 'sendPluginMetrics' })
         })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import { Kafka } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { JobQueueManager } from 'main/job-queues/job-queue-manager'
 import { Job } from 'node-schedule'
-import { Pool } from 'pg'
+import { Pool, QueryResult } from 'pg'
 import { VM } from 'vm2'
 
 import { DB } from './utils/db/db'
@@ -328,6 +328,7 @@ export type VMMethods = {
     onSnapshot?: (event: PluginEvent) => Promise<void>
     exportEvents?: (events: PluginEvent[]) => Promise<void>
     processEvent?: (event: PluginEvent) => Promise<PluginEvent>
+    importEventsFromRedshift?: (queryResult: QueryResult<any>) => Promise<PluginEvent[]>
 }
 
 export interface PluginConfigVMResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import { Kafka } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { JobQueueManager } from 'main/job-queues/job-queue-manager'
 import { Job } from 'node-schedule'
-import { Pool, QueryResult } from 'pg'
+import { Pool, QueryResult, QueryResultRow } from 'pg'
 import { VM } from 'vm2'
 
 import { DB } from './utils/db/db'
@@ -328,7 +328,7 @@ export type VMMethods = {
     onSnapshot?: (event: PluginEvent) => Promise<void>
     exportEvents?: (events: PluginEvent[]) => Promise<void>
     processEvent?: (event: PluginEvent) => Promise<PluginEvent>
-    importEventsFromRedshift?: (queryResult: QueryResult<any>) => Promise<PluginEvent[]>
+    importEventsFromRedshift?: (rows: QueryResultRow[]) => Promise<PluginEvent[]>
 }
 
 export interface PluginConfigVMResponse {

--- a/src/worker/vm/upgrades/imports/redshift.ts
+++ b/src/worker/vm/upgrades/imports/redshift.ts
@@ -1,0 +1,165 @@
+import { Plugin, PluginEvent, PluginMeta, RetryError } from '@posthog/plugin-scaffold'
+import { Client, QueryResult } from 'pg'
+
+import { Hub, PluginConfig, PluginConfigVMInternalResponse, PluginTaskType } from '../../../../types'
+
+type RedshiftImportUpgrade = Plugin<{
+    global: {
+        pgClient: Client
+        eventsToIgnore: Set<string>
+        sanitizedTableName: string
+        importAndIngestEvents: (
+            payload: ImportEventsJobPayload,
+            meta: PluginMeta<RedshiftImportUpgrade>
+        ) => Promise<void>
+    }
+    config: {
+        clusterHost: string
+        clusterPort: string
+        dbName: string
+        tableName: string
+        dbUsername: string
+        dbPassword: string
+        eventsToIgnore: string
+        orderByColumn: string
+    }
+}>
+
+interface ImportEventsJobPayload extends Record<string, any> {
+    offset: number
+    retriesPerformedSoFar: number
+}
+
+interface ExecuteQueryResponse {
+    error: Error | null
+    queryResult: QueryResult<any> | null
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare namespace posthog {
+    function capture(event: string, properties?: Record<string, any>): void
+}
+
+const sanitizeSqlIdentifier = (unquotedIdentifier: string): string => {
+    return unquotedIdentifier.replace(/[^\w\d_]+/g, '')
+}
+
+export function upgradeRedshiftImport(
+    response: PluginConfigVMInternalResponse<PluginMeta<RedshiftImportUpgrade>>
+): void {
+    const { methods, tasks, meta } = response
+
+    const oldSetupPlugin = methods.setupPlugin
+    methods.setupPlugin = async () => {
+        console.log('IVE BEEN SETUP')
+
+        const requiredConfigOptions = ['clusterHost', 'clusterPort', 'dbName', 'dbUsername', 'dbPassword']
+        for (const option of requiredConfigOptions) {
+            if (!(option in meta.config)) {
+                throw new Error(`Required config option ${option} is missing!`)
+            }
+        }
+
+        if (!meta.config.clusterHost.endsWith('redshift.amazonaws.com')) {
+            throw new Error('Cluster host must be a valid AWS Redshift host')
+        }
+
+        const testQuery = await executeQuery('SELECT 1', [], meta)
+
+        if (testQuery.error) {
+            throw new Error('Unable to connect to Redshift!')
+        }
+
+        await oldSetupPlugin?.()
+
+        const offset = await meta.storage.get('import_offset', 0)
+
+        await meta.jobs.importAndIngestEvents({ offset, retriesPerformedSoFar: 0 }).runNow()
+    }
+
+    meta.global.importAndIngestEvents = async (
+        payload: ImportEventsJobPayload,
+        meta: PluginMeta<RedshiftImportUpgrade>
+    ) => {
+        if (payload.retriesPerformedSoFar >= 15) {
+            console.error(
+                `Import error: Unable to process rows ${payload.offset}-${payload.offset + 100}. Skipped them.`
+            )
+            return
+        }
+
+        const query = `SELECT * FROM $1 ORDER BY $2 OFFSET $3 LIMIT 100;`
+        const values = [
+            sanitizeSqlIdentifier(meta.config.tableName),
+            sanitizeSqlIdentifier(meta.config.orderByColumn),
+            payload.offset,
+        ]
+
+        const queryResponse = await executeQuery(query, values, meta)
+
+        if (queryResponse.error || !queryResponse.queryResult) {
+            const nextRetrySeconds = 2 ** payload.retriesPerformedSoFar * 3
+            console.log(
+                `Unable to process rows ${payload.offset}-${
+                    payload.offset + 100
+                }. Retrying in ${nextRetrySeconds}. Error: ${queryResponse.error}`
+            )
+            await meta.jobs
+                .importAndIngestEvents({ ...payload, retriesPerformedSoFar: payload.retriesPerformedSoFar + 1 })
+                .runIn(nextRetrySeconds, 'seconds')
+        }
+
+        const eventsToIngest = await methods.importEventsFromRedshift!(queryResponse.queryResult!)
+
+        if (!Array.isArray(eventsToIngest)) {
+            throw new Error('importEventsFromRedshift must return an array of plugin events')
+        }
+
+        console.log('OFFSET', payload.offset)
+        for (const event of eventsToIngest) {
+            console.log(event.event)
+            posthog.capture(event.event, event.properties)
+        }
+
+        await meta.storage.set('import_offset', payload.offset + 100)
+        await meta.jobs
+            .importAndIngestEvents({ offset: payload.offset + 100, retriesPerformedSoFar: 0 })
+            .runIn(10, 'seconds')
+    }
+
+    async function executeQuery(
+        query: string,
+        values: any[],
+        meta: PluginMeta<RedshiftImportUpgrade>
+    ): Promise<ExecuteQueryResponse> {
+        const { config } = meta
+
+        const pgClient = new Client({
+            user: config.dbUsername,
+            password: config.dbPassword,
+            host: config.clusterHost,
+            database: config.dbName,
+            port: parseInt(config.clusterPort),
+        })
+
+        await pgClient.connect()
+
+        let error: Error | null = null
+        let queryResult: QueryResult<any> | null = null
+        try {
+            queryResult = await pgClient.query(query, values)
+        } catch (err) {
+            error = err
+        }
+
+        await pgClient.end()
+
+        return { error, queryResult }
+    }
+
+    tasks.job['importAndIngestEvents'] = {
+        name: 'importAndIngestEvents',
+        type: PluginTaskType.Job,
+        exec: (payload) => meta.global.importAndIngestEvents(payload as ImportEventsJobPayload, meta),
+    }
+}

--- a/src/worker/vm/upgrades/imports/redshift.ts
+++ b/src/worker/vm/upgrades/imports/redshift.ts
@@ -2,6 +2,10 @@ import { Plugin, PluginEvent, PluginMeta, RetryError } from '@posthog/plugin-sca
 import { Client, QueryResult } from 'pg'
 
 import { Hub, PluginConfig, PluginConfigVMInternalResponse, PluginTaskType } from '../../../../types'
+import { createPosthog } from './../../extensions/posthog'
+import { DummyPostHog } from './../../extensions/posthog'
+
+// TODO: Add automatic metrics
 
 type RedshiftImportUpgrade = Plugin<{
     global: {
@@ -12,6 +16,9 @@ type RedshiftImportUpgrade = Plugin<{
             payload: ImportEventsJobPayload,
             meta: PluginMeta<RedshiftImportUpgrade>
         ) => Promise<void>
+        initialOffset: number
+        posthog: DummyPostHog
+        totalRows: number
     }
     config: {
         clusterHost: string
@@ -26,7 +33,7 @@ type RedshiftImportUpgrade = Plugin<{
 }>
 
 interface ImportEventsJobPayload extends Record<string, any> {
-    offset: number
+    offset?: number
     retriesPerformedSoFar: number
 }
 
@@ -35,24 +42,21 @@ interface ExecuteQueryResponse {
     queryResult: QueryResult<any> | null
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-declare namespace posthog {
-    function capture(event: string, properties?: Record<string, any>): void
-}
+const EVENTS_PER_BATCH = 10
 
 const sanitizeSqlIdentifier = (unquotedIdentifier: string): string => {
     return unquotedIdentifier.replace(/[^\w\d_]+/g, '')
 }
 
 export function upgradeRedshiftImport(
+    hub: Hub,
+    pluginConfig: PluginConfig,
     response: PluginConfigVMInternalResponse<PluginMeta<RedshiftImportUpgrade>>
 ): void {
     const { methods, tasks, meta } = response
 
     const oldSetupPlugin = methods.setupPlugin
     methods.setupPlugin = async () => {
-        console.log('IVE BEEN SETUP')
-
         const requiredConfigOptions = ['clusterHost', 'clusterPort', 'dbName', 'dbUsername', 'dbPassword']
         for (const option of requiredConfigOptions) {
             if (!(option in meta.config)) {
@@ -64,44 +68,71 @@ export function upgradeRedshiftImport(
             throw new Error('Cluster host must be a valid AWS Redshift host')
         }
 
-        const testQuery = await executeQuery('SELECT 1', [], meta)
-
-        if (testQuery.error) {
+        // the way this is done means we'll continuously import as the table grows
+        // to only import historical data, we should set a totalRows value in storage once
+        const totalRowsResult = await executeQuery(
+            `SELECT COUNT(1) FROM ${sanitizeSqlIdentifier(meta.config.tableName)}`,
+            [],
+            meta
+        )
+        if (totalRowsResult.error || !totalRowsResult.queryResult) {
             throw new Error('Unable to connect to Redshift!')
         }
+        meta.global.totalRows = Number(totalRowsResult.queryResult.rows[0].count)
+
+        // we're outside the vm so need to recreate this
+        meta.global.posthog = createPosthog(hub, pluginConfig)
 
         await oldSetupPlugin?.()
 
+        // used for picking up where we left off after a restart
         const offset = await meta.storage.get('import_offset', 0)
 
-        await meta.jobs.importAndIngestEvents({ offset, retriesPerformedSoFar: 0 }).runNow()
+        // needed to prevent race conditions around offsets leading to events ingested twice
+        meta.global.initialOffset = Number(offset)
+        await meta.cache.set('import_offset', Number(offset) / EVENTS_PER_BATCH)
+
+        await meta.jobs.importAndIngestEvents({ retriesPerformedSoFar: 0 }).runIn(10, 'seconds')
     }
 
     meta.global.importAndIngestEvents = async (
         payload: ImportEventsJobPayload,
         meta: PluginMeta<RedshiftImportUpgrade>
     ) => {
-        if (payload.retriesPerformedSoFar >= 15) {
+        if (payload.offset && payload.retriesPerformedSoFar >= 15) {
             console.error(
-                `Import error: Unable to process rows ${payload.offset}-${payload.offset + 100}. Skipped them.`
+                `Import error: Unable to process rows ${payload.offset}-${
+                    payload.offset + EVENTS_PER_BATCH
+                }. Skipped them.`
             )
             return
         }
 
-        const query = `SELECT * FROM $1 ORDER BY $2 OFFSET $3 LIMIT 100;`
-        const values = [
-            sanitizeSqlIdentifier(meta.config.tableName),
-            sanitizeSqlIdentifier(meta.config.orderByColumn),
-            payload.offset,
-        ]
+        let offset: number
+        if (payload.offset) {
+            offset = payload.offset
+        } else {
+            const redisIncrementedOffset = await meta.cache.incr('import_offset')
+            offset = meta.global.initialOffset + (redisIncrementedOffset - 1) * EVENTS_PER_BATCH
+        }
+
+        if (offset > meta.global.totalRows) {
+            console.log(`Done processing all rows in ${meta.config.tableName}`)
+            return
+        }
+
+        const query = `SELECT * FROM ${sanitizeSqlIdentifier(meta.config.tableName)} ORDER BY ${sanitizeSqlIdentifier(
+            meta.config.orderByColumn
+        )} OFFSET $1 LIMIT ${EVENTS_PER_BATCH};`
+        const values = [offset]
 
         const queryResponse = await executeQuery(query, values, meta)
 
         if (queryResponse.error || !queryResponse.queryResult) {
             const nextRetrySeconds = 2 ** payload.retriesPerformedSoFar * 3
             console.log(
-                `Unable to process rows ${payload.offset}-${
-                    payload.offset + 100
+                `Unable to process rows ${offset}-${
+                    offset + EVENTS_PER_BATCH
                 }. Retrying in ${nextRetrySeconds}. Error: ${queryResponse.error}`
             )
             await meta.jobs
@@ -109,22 +140,24 @@ export function upgradeRedshiftImport(
                 .runIn(nextRetrySeconds, 'seconds')
         }
 
-        const eventsToIngest = await methods.importEventsFromRedshift!(queryResponse.queryResult!)
+        const eventsToIngest = await methods.importEventsFromRedshift!(queryResponse.queryResult!.rows)
 
         if (!Array.isArray(eventsToIngest)) {
             throw new Error('importEventsFromRedshift must return an array of plugin events')
         }
 
-        console.log('OFFSET', payload.offset)
         for (const event of eventsToIngest) {
             console.log(event.event)
-            posthog.capture(event.event, event.properties)
+            meta.global.posthog.capture(event.event, event.properties)
         }
 
-        await meta.storage.set('import_offset', payload.offset + 100)
-        await meta.jobs
-            .importAndIngestEvents({ offset: payload.offset + 100, retriesPerformedSoFar: 0 })
-            .runIn(10, 'seconds')
+        await meta.storage.set('import_offset', offset + EVENTS_PER_BATCH)
+        await meta.jobs.importAndIngestEvents({ offset: offset + EVENTS_PER_BATCH, retriesPerformedSoFar: 0 }).runNow()
+    }
+
+    methods.teardownPlugin = async () => {
+        const redisOffset = await meta.cache.get('import_offset', 0)
+        await meta.storage.set('import_offset', Number(redisOffset) * EVENTS_PER_BATCH)
     }
 
     async function executeQuery(

--- a/src/worker/vm/vm.ts
+++ b/src/worker/vm/vm.ts
@@ -14,6 +14,7 @@ import { createStorage } from './extensions/storage'
 import { imports } from './imports'
 import { transformCode } from './transforms'
 import { upgradeExportEvents } from './upgrades/export-events'
+import { upgradeRedshiftImport } from './upgrades/imports/redshift'
 
 export class TimeoutError extends Error {
     name = 'TimeoutError'
@@ -218,6 +219,10 @@ export async function createPluginConfigVM(
 
     if (exportEventsExists) {
         upgradeExportEvents(hub, pluginConfig, vmResponse)
+    }
+
+    if (!!methods.importEventsFromRedshift) {
+        upgradeRedshiftImport(vmResponse)
     }
 
     setupMetrics(hub, pluginConfig, metrics, exportEventsExists)

--- a/src/worker/vm/vm.ts
+++ b/src/worker/vm/vm.ts
@@ -168,6 +168,7 @@ export async function createPluginConfigVM(
                 onEvent: __asyncFunctionGuard(__bindMeta('onEvent'), 'onEvent'),
                 onSnapshot: __asyncFunctionGuard(__bindMeta('onSnapshot'), 'onSnapshot'),
                 processEvent: __asyncFunctionGuard(__bindMeta('processEvent'), 'processEvent'),
+                importEventsFromRedshift: __asyncFunctionGuard(__bindMeta('importEventsFromRedshift'), 'importEventsFromRedshift'),
             };
 
             const __tasks = {
@@ -222,7 +223,7 @@ export async function createPluginConfigVM(
     }
 
     if (!!methods.importEventsFromRedshift) {
-        upgradeRedshiftImport(vmResponse)
+        upgradeRedshiftImport(hub, pluginConfig, vmResponse)
     }
 
     setupMetrics(hub, pluginConfig, metrics, exportEventsExists)

--- a/src/worker/vm/vm.ts
+++ b/src/worker/vm/vm.ts
@@ -216,9 +216,8 @@ export async function createPluginConfigVM(
 
     const vmResponse = vm.run(responseVar)
     const { methods, tasks, metrics } = vmResponse
-    const exportEventsExists = !!methods.exportEvents
 
-    if (exportEventsExists) {
+    if (!!methods.exportEvents) {
         upgradeExportEvents(hub, pluginConfig, vmResponse)
     }
 
@@ -226,7 +225,7 @@ export async function createPluginConfigVM(
         upgradeRedshiftImport(hub, pluginConfig, vmResponse)
     }
 
-    setupMetrics(hub, pluginConfig, metrics, exportEventsExists)
+    setupMetrics(hub, pluginConfig, metrics, methods)
 
     await vm.run(`${responseVar}.methods.setupPlugin?.()`)
 


### PR DESCRIPTION
### This is just a prototype and a discussion thread!
----
# Motivation

I think the next 2 big things for plugins are #406 and import plugins. I'd like to tackle those once I'm back.

Nevertheless, following a talk with @jamesefhawkins about a potential user looking to import their Redshift data to us, I decided to give the process a try and use this **draft** PR as a discussion thread.

# What this PR does

It introduces a VM method (wait! discussion coming below) `importEventsFromRedshift` that allows devs to write just a function to transform their table data into a PostHog event and we'll query their table and ingest events from it. Very Segment-like. Like so:

<img width="1437" alt="Screenshot 2021-07-16 at 08 24 24" src="https://user-images.githubusercontent.com/38760734/125940520-db52c0ca-8b67-49db-8ad5-53274321617a.png">

`importEventsFromRedshift` takes the rows resulted from a `SELECT *` on a specified table and allows devs to transform it **however they like**, such that events come out of the other end.

It significantly reduces the barrier to writing an import plugin, as all of this is handled for you:

- Connection to Redshift
- Querying in a safe and optimized way (no duplicates) across multiple threads
- Plugin server restarts
- Ingesting the events
- Logs 
- Metrics
- Input validation

<img width="1438" alt="Screenshot 2021-07-16 at 08 00 31" src="https://user-images.githubusercontent.com/38760734/125941273-a0ecd71c-61f8-444f-88c1-cded851621d3.png">
<img width="1439" alt="Screenshot 2021-07-16 at 08 16 29" src="https://user-images.githubusercontent.com/38760734/125941314-66790b03-15f1-4b1e-9867-783497762ae7.png">

# Considerations

## Current Approach

### Pros

- Super simple to write a plugin to import data

### Cons

- Bulks up the plugin server codebase with platform-specific code. Should we support some key third-party services (BQ, Redshift, Snowflake) natively or none at all? Where do we stop once we start adding more and more of these functions?
- We'd need to approve every transformation someone writes. This is the case with this and any other approach until #454 is done. I think one thing we could do here UX-wise is have a config option on Cloud to allow installations from certain URLs, or "hidden plugins". This way at least everyone's plugins repository isn't filled with everyone else's transformations.
- The dev still needs to specify a config, although there's ways to simplify this if we wanted to

## Alternatives

### Perfect World Solutions

The best solution I can envision is #454 done to perfection so that we can write **one single** import plugin per warehouse that takes code as an input for the transformation and does all the rest. This would be like a "plugin-in-plugin" scenario, and would look very much like what Segment does. If we ever get to where we want to get in terms of security when running arbitrary code on our servers, there's no reason a plugin couldn't itself take in arbitrary code and run it with some eval-like method.

The second best thing would be if this were part of `plugin-contrib` somehow. It'd work essentially the same way, except we'd move the code from one repo to another, which conceptually makes more sense. This would need a bit of glue to work and wouldn't be as nice, but could be a good approach.

### Down to Earth 

If we decide that providing a method like this natively is not a great idea, we can just provide this as a template. After all, this is just an import plugin with a function missing. This is worse because users have to see all this complicated code instead of it just "magically working", but might make sense to do conceptually.

# Other relevant points

- I originally wrote the first test with an `ORDER BY` clause so offsets could be used reliably. The problem is, if the table is to be ordered by an arbitrary column at query-time, this simply won't work. An `ORDER BY timestamp` query on PostHog events I had in Redshift took several minutes to process around 200k rows. There's many ways to go with this, from things like sort keys, [keeping your Redshift table sorted](https://aws.amazon.com/about-aws/whats-new/2019/11/amazon-redshift-introduces-automatic-table-sort-alternative-vacuum-sort/) to us using another mechanism like greater than/smaller than `WHERE` clauses. They all come with their own considerations though, particularly as it pertains to reliable ingestion across multiple threads, so this needs a bit more thought. Could also consider using platform-specific functions like [`UNLOAD`](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html).

