### PR TITLE
Save distinct ids on clickhouse person table

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -480,6 +480,7 @@ export interface ClickHousePerson {
     is_identified: number
     is_deleted: number
     timestamp: string
+    distinct_ids: string[]
 }
 
 /** Usable PersonDistinctId model. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,6 +466,11 @@ export interface Person extends BasePerson {
     created_at: DateTime
 }
 
+/** Returned by fetchPerson */
+export interface PersonWithDistinctIds extends Person {
+    distinct_ids: string[]
+}
+
 /** Clickhouse Person model. */
 export interface ClickHousePerson {
     id: string

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -26,6 +26,7 @@ import {
     Hook,
     Person,
     PersonDistinctId,
+    PersonWithDistinctIds,
     PluginConfig,
     PluginLogEntry,
     PluginLogEntrySource,
@@ -339,24 +340,36 @@ export class DB {
         }
     }
 
-    public async fetchPerson(teamId: number, distinctId: string): Promise<Person | undefined> {
+    public async fetchPerson(teamId: number, distinctId: string): Promise<PersonWithDistinctIds | undefined> {
         const selectResult = await this.postgresQuery(
-            `SELECT
-                posthog_person.id, posthog_person.created_at, posthog_person.team_id, posthog_person.properties,
-                posthog_person.is_user_id, posthog_person.is_identified, posthog_person.uuid,
-                posthog_persondistinctid.team_id AS persondistinctid__team_id,
-                posthog_persondistinctid.distinct_id AS persondistinctid__distinct_id
-            FROM posthog_person
-            JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
-            WHERE
-                posthog_person.team_id = $1
-                AND posthog_persondistinctid.team_id = $1
-                AND posthog_persondistinctid.distinct_id = $2`,
+            `
+            WITH person_id_cte AS (
+                SELECT person_id
+                FROM posthog_persondistinctid
+                WHERE team_id = $1 AND distinct_id = $2
+            )
+            SELECT
+                id,
+                created_at,
+                team_id,
+                properties,
+                is_user_id,
+                is_identified,
+                uuid,
+                array(
+                    SELECT distinct_id
+                    FROM posthog_persondistinctid t
+                    WHERE t.team_id = $1 AND t.person_id = p.id
+                ) AS distinct_ids
+            FROM posthog_person p
+            JOIN person_id_cte ON (person_id_cte.person_id = p.id)
+            WHERE team_id = $1
+            `,
             [teamId, distinctId],
             'fetchPerson'
         )
         if (selectResult.rows.length > 0) {
-            const rawPerson: RawPerson = selectResult.rows[0]
+            const rawPerson: RawPerson & { distinct_ids: string[] } = selectResult.rows[0]
             return { ...rawPerson, created_at: DateTime.fromISO(rawPerson.created_at).toUTC() }
         }
     }
@@ -368,8 +381,8 @@ export class DB {
         isUserId: number | null,
         isIdentified: boolean,
         uuid: string,
-        distinctIds?: string[]
-    ): Promise<Person> {
+        distinctIds: string[]
+    ): Promise<PersonWithDistinctIds> {
         const kafkaMessages: ProducerRecord[] = []
 
         const person = await this.postgresTransaction(async (client) => {
@@ -381,7 +394,8 @@ export class DB {
             const person = {
                 ...personCreated,
                 created_at: DateTime.fromISO(personCreated.created_at).toUTC(),
-            } as Person
+                distinct_ids: distinctIds,
+            } as PersonWithDistinctIds
 
             if (this.kafkaProducer) {
                 kafkaMessages.push({
@@ -399,6 +413,7 @@ export class DB {
                                     is_identified: isIdentified,
                                     id: uuid,
                                     is_deleted: 0,
+                                    distinct_ids: distinctIds,
                                 })
                             ),
                         },
@@ -425,16 +440,23 @@ export class DB {
         return person
     }
 
-    public async updatePerson(person: Person, update: Partial<Person>): Promise<Person> {
-        const updatedPerson: Person = { ...person, ...update }
-        const values = [...Object.values(unparsePersonPartial(update)), person.id]
-        await this.postgresQuery(
-            `UPDATE posthog_person SET ${Object.keys(update).map(
-                (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
-            )} WHERE id = $${Object.values(update).length + 1}`,
-            values,
-            'updatePerson'
-        )
+    public async updatePerson(
+        person: PersonWithDistinctIds,
+        update: Partial<Person>,
+        updatedDistinctIds?: string[]
+    ): Promise<PersonWithDistinctIds> {
+        const updatedPerson: PersonWithDistinctIds = { ...person, ...update }
+        if (update) {
+            // :TODO: Avoid this when only updating distinct_ids
+            const values = [...Object.values(unparsePersonPartial(update)), person.id]
+            await this.postgresQuery(
+                `UPDATE posthog_person SET ${Object.keys(update).map(
+                    (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
+                )} WHERE id = $${Object.values(update).length + 1}`,
+                values,
+                'updatePerson'
+            )
+        }
 
         if (this.kafkaProducer) {
             await this.kafkaProducer.queueMessage({
@@ -451,6 +473,7 @@ export class DB {
                                 team_id: updatedPerson.team_id,
                                 is_identified: updatedPerson.is_identified,
                                 id: updatedPerson.uuid,
+                                distinct_ids: updatedDistinctIds || person.distinct_ids,
                             })
                         ),
                     },
@@ -491,7 +514,7 @@ export class DB {
         return newProperties
     }
 
-    public async deletePerson(person: Person): Promise<void> {
+    public async deletePerson(person: PersonWithDistinctIds): Promise<void> {
         await this.postgresTransaction(async (client) => {
             await client.query('DELETE FROM posthog_person WHERE team_id = $1 AND id = $2', [person.team_id, person.id])
         })
@@ -511,6 +534,7 @@ export class DB {
                                 is_identified: person.is_identified,
                                 id: person.uuid,
                                 is_deleted: 1,
+                                distinct_ids: person.distinct_ids,
                             })
                         ),
                     },
@@ -557,16 +581,13 @@ export class DB {
         return personDistinctIds.map((pdi) => pdi.distinct_id)
     }
 
-    public async addDistinctId(person: Person, distinctId: string): Promise<void> {
-        const kafkaMessage = await this.addDistinctIdPooled(this.postgres, person, distinctId)
-        if (this.kafkaProducer && kafkaMessage) {
-            await this.kafkaProducer.queueMessage(kafkaMessage)
-        }
+    public async addDistinctId(person: PersonWithDistinctIds, distinctId: string): Promise<void> {
+        await this.addDistinctIdPooled(this.postgres, person, distinctId)
     }
 
     public async addDistinctIdPooled(
         client: PoolClient | Pool,
-        person: Person,
+        person: PersonWithDistinctIds,
         distinctId: string
     ): Promise<ProducerRecord | void> {
         const insertResult = await client.query(
@@ -576,7 +597,7 @@ export class DB {
 
         const personDistinctIdCreated = insertResult.rows[0] as PersonDistinctId
         if (this.kafkaProducer) {
-            return {
+            await this.kafkaProducer.queueMessage({
                 topic: KAFKA_PERSON_UNIQUE_ID,
                 messages: [
                     {
@@ -585,11 +606,12 @@ export class DB {
                         ),
                     },
                 ],
-            }
+            })
+            await this.updatePerson(person, {}, [...person.distinct_ids, personDistinctIdCreated.distinct_id])
         }
     }
 
-    public async moveDistinctIds(source: Person, target: Person): Promise<void> {
+    public async moveDistinctIds(source: PersonWithDistinctIds, target: PersonWithDistinctIds): Promise<void> {
         const movedDistinctIdResult = await this.postgresQuery(
             `
                 UPDATE posthog_persondistinctid
@@ -603,6 +625,8 @@ export class DB {
         )
 
         if (this.kafkaProducer) {
+            const distinctIds = [...source.distinct_ids, ...target.distinct_ids]
+            await this.updatePerson(target, {}, distinctIds)
             for (const row of movedDistinctIdResult.rows) {
                 await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON_UNIQUE_ID,

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -442,7 +442,7 @@ export class DB {
 
     public async updatePerson(
         person: PersonWithDistinctIds,
-        update: Partial<Person>,
+        update: Partial<Person> | undefined,
         updatedDistinctIds?: string[]
     ): Promise<PersonWithDistinctIds> {
         const updatedPerson: PersonWithDistinctIds = { ...person, ...update }
@@ -607,7 +607,7 @@ export class DB {
                     },
                 ],
             })
-            await this.updatePerson(person, {}, [...person.distinct_ids, personDistinctIdCreated.distinct_id])
+            await this.updatePerson(person, undefined, [...person.distinct_ids, personDistinctIdCreated.distinct_id])
         }
     }
 
@@ -626,7 +626,7 @@ export class DB {
 
         if (this.kafkaProducer) {
             const distinctIds = [...source.distinct_ids, ...target.distinct_ids]
-            await this.updatePerson(target, {}, distinctIds)
+            await this.updatePerson(target, undefined, distinctIds)
             for (const row of movedDistinctIdResult.rows) {
                 await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON_UNIQUE_ID,

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -13,6 +13,7 @@ import {
     Hub,
     Person,
     PersonDistinctId,
+    PersonWithDistinctIds,
     PostgresSessionRecordingEvent,
     SessionRecordingEvent,
     TeamId,
@@ -334,7 +335,7 @@ export class EventsProcessor {
         }
     }
 
-    public async mergePeople(mergeInto: Person, otherPerson: Person): Promise<void> {
+    public async mergePeople(mergeInto: PersonWithDistinctIds, otherPerson: PersonWithDistinctIds): Promise<void> {
         let firstSeen = mergeInto.created_at
 
         // Merge properties

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -1,7 +1,15 @@
 import { DateTime } from 'luxon'
 
 import { startPluginsServer } from '../../src/main/pluginsServer'
-import { Database, Hub, LogLevel, PluginsServerConfig, Team, TimestampFormat } from '../../src/types'
+import {
+    Database,
+    Hub,
+    LogLevel,
+    PersonWithDistinctIds,
+    PluginsServerConfig,
+    Team,
+    TimestampFormat,
+} from '../../src/types'
 import { castTimestampOrNow, UUIDT } from '../../src/utils/utils'
 import { makePiscina } from '../../src/worker/piscina'
 import { createPosthog, DummyPostHog } from '../../src/worker/vm/extensions/posthog'
@@ -99,6 +107,7 @@ describe('postgres parity', () => {
                 properties: '{"userProp":"propValue"}',
                 is_identified: 1,
                 is_deleted: 0,
+                distinct_ids: expect.arrayContaining(['distinct1', 'distinct2']),
                 _timestamp: expect.any(String),
                 _offset: expect.any(Number),
             },
@@ -106,24 +115,21 @@ describe('postgres parity', () => {
         const clickHouseDistinctIds = await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)
         expect(clickHouseDistinctIds).toEqual(['distinct1', 'distinct2'])
 
-        const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
-        expect(postgresPersons).toEqual([
-            {
-                id: expect.any(Number),
-                created_at: expect.any(DateTime),
-                properties: {
-                    userProp: 'propValue',
-                },
-                team_id: 2,
-                is_user_id: null,
-                is_identified: true,
-                uuid: uuid,
+        const postgresPerson = await hub.db.fetchPerson(team.id, 'distinct1')
+        expect(postgresPerson).toEqual({
+            id: expect.any(Number),
+            created_at: expect.any(DateTime),
+            properties: {
+                userProp: 'propValue',
             },
-        ])
-        const postgresDistinctIds = await hub.db.fetchDistinctIdValues(person, Database.Postgres)
-        expect(postgresDistinctIds).toEqual(['distinct1', 'distinct2'])
+            team_id: 2,
+            is_user_id: null,
+            is_identified: true,
+            uuid: uuid,
+            distinct_ids: expect.arrayContaining(['distinct1', 'distinct2']),
+        })
 
-        expect(person).toEqual(postgresPersons[0])
+        expect(person).toEqual(postgresPerson)
     })
 
     test('updatePerson', async () => {
@@ -160,11 +166,16 @@ describe('postgres parity', () => {
         expect(clickHousePersons[0].is_identified).toEqual(1)
         expect(clickHousePersons[0].is_deleted).toEqual(0)
         expect(clickHousePersons[0].properties).toEqual('{"replacedUserProp":"propValue"}')
+        expect(clickHousePersons[0].distinct_ids).toEqual(expect.arrayContaining(['distinct1', 'distinct2']))
 
         // update date and boolean to false
 
         const randomDate = DateTime.utc().minus(100000).setZone('UTC')
-        await hub.db.updatePerson(person, { created_at: randomDate, is_identified: false })
+        await hub.db.updatePerson(person, { created_at: randomDate, is_identified: false }, [
+            'distinct1',
+            'distinct2',
+            'distinct3',
+        ])
 
         await delayUntilEventIngested(async () =>
             (await hub.db.fetchPersons(Database.ClickHouse)).filter((p) => !p.is_identified)
@@ -183,6 +194,9 @@ describe('postgres parity', () => {
         expect(clickHousePersons2[0].created_at).toEqual(
             // TODO: get rid of `+ '.000'` by removing the need for ClickHouseSecondPrecision on CH persons
             castTimestampOrNow(randomDate, TimestampFormat.ClickHouseSecondPrecision) + '.000'
+        )
+        expect(clickHousePersons2[0].distinct_ids).toEqual(
+            expect.arrayContaining(['distinct1', 'distinct2', 'distinct3'])
         )
     })
 

--- a/tests/shared/db.test.ts
+++ b/tests/shared/db.test.ts
@@ -1,7 +1,6 @@
 import { Hub, PropertyOperator } from '../../src/types'
 import { DB } from '../../src/utils/db/db'
 import { createHub } from '../../src/utils/db/hub'
-import { ActionManager } from '../../src/worker/ingestion/action-manager'
 import { resetTestDatabase } from '../helpers/sql'
 
 describe('DB', () => {

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -3,7 +3,16 @@ import * as IORedis from 'ioredis'
 import { DateTime } from 'luxon'
 import { performance } from 'perf_hooks'
 
-import { Database, Event, Hub, LogLevel, Person, PluginsServerConfig, Team } from '../../src/types'
+import {
+    Database,
+    Event,
+    Hub,
+    LogLevel,
+    Person,
+    PersonWithDistinctIds,
+    PluginsServerConfig,
+    Team,
+} from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import { hashElements } from '../../src/utils/db/utils'
 import { posthog } from '../../src/utils/posthog'
@@ -43,7 +52,7 @@ async function createPerson(
     team: Team,
     distinctIds: string[],
     properties: Record<string, any> = {}
-): Promise<Person> {
+): Promise<PersonWithDistinctIds> {
     return server.db.createPerson(DateTime.utc(), properties, team.id, null, false, new UUIDT().toString(), distinctIds)
 }
 
@@ -171,7 +180,8 @@ export const createProcessEventTests = (
         }
 
         expect((await hub.db.fetchPersons()).length).toEqual(2)
-        const [person0, person1] = await hub.db.fetchPersons()
+        const person0 = (await hub.db.fetchPerson(team.id, 'person_0'))!
+        const person1 = (await hub.db.fetchPerson(team.id, 'person_1'))!
 
         await eventsProcessor.mergePeople(person0, person1)
 

--- a/tests/worker/ingestion/ingest-event.test.ts
+++ b/tests/worker/ingestion/ingest-event.test.ts
@@ -112,8 +112,7 @@ describe('ingestEvent', () => {
                     is_user_id: null,
                     is_identified: false,
                     uuid: expect.any(String),
-                    persondistinctid__team_id: 2,
-                    persondistinctid__distinct_id: 'abc',
+                    distinct_ids: ['abc'],
                 },
             },
         }


### PR DESCRIPTION
This change adds support for populating `person.distinct_ids` column in clickhouse. 

Note that the implementation "seems" correct but is very susceptible to race conditions around fetching and then updating person entries. If the experiment is successful, the next step is to use locking to remove the raciness.

Issue: https://github.com/PostHog/posthog/issues/5167

Depends on https://github.com/PostHog/posthog/pull/5276

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
