### PR TITLE
Revert "Save distinct ids on clickhouse person table"

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -466,11 +466,6 @@ export interface Person extends BasePerson {
     created_at: DateTime
 }
 
-/** Returned by fetchPerson */
-export interface PersonWithDistinctIds extends Person {
-    distinct_ids: string[]
-}
-
 /** Clickhouse Person model. */
 export interface ClickHousePerson {
     id: string
@@ -480,7 +475,6 @@ export interface ClickHousePerson {
     is_identified: number
     is_deleted: number
     timestamp: string
-    distinct_ids: string[]
 }
 
 /** Usable PersonDistinctId model. */

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -13,7 +13,6 @@ import {
     Hub,
     Person,
     PersonDistinctId,
-    PersonWithDistinctIds,
     PostgresSessionRecordingEvent,
     SessionRecordingEvent,
     TeamId,
@@ -335,7 +334,7 @@ export class EventsProcessor {
         }
     }
 
-    public async mergePeople(mergeInto: PersonWithDistinctIds, otherPerson: PersonWithDistinctIds): Promise<void> {
+    public async mergePeople(mergeInto: Person, otherPerson: Person): Promise<void> {
         let firstSeen = mergeInto.created_at
 
         // Merge properties

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -1,15 +1,7 @@
 import { DateTime } from 'luxon'
 
 import { startPluginsServer } from '../../src/main/pluginsServer'
-import {
-    Database,
-    Hub,
-    LogLevel,
-    PersonWithDistinctIds,
-    PluginsServerConfig,
-    Team,
-    TimestampFormat,
-} from '../../src/types'
+import { Database, Hub, LogLevel, PluginsServerConfig, Team, TimestampFormat } from '../../src/types'
 import { castTimestampOrNow, UUIDT } from '../../src/utils/utils'
 import { makePiscina } from '../../src/worker/piscina'
 import { createPosthog, DummyPostHog } from '../../src/worker/vm/extensions/posthog'
@@ -59,36 +51,6 @@ describe('postgres parity', () => {
         await stopServer()
     })
 
-    test('fetchPerson', async () => {
-        const uuid = new UUIDT().toString()
-        const person = await hub.db.createPerson(
-            DateTime.utc(),
-            { userProp: 'propValue' },
-            team.id,
-            null,
-            false,
-            uuid,
-            ['distinct1', 'distinct2']
-        )
-        await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
-        await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
-
-        const fetchedPerson = await hub.db.fetchPerson(team.id, 'distinct2')
-
-        expect(fetchedPerson).toEqual({
-            id: expect.any(Number),
-            created_at: expect.any(DateTime),
-            properties: {
-                userProp: 'propValue',
-            },
-            team_id: 2,
-            is_user_id: null,
-            is_identified: false,
-            uuid: uuid,
-            distinct_ids: ['distinct1', 'distinct2'],
-        })
-    })
-
     test('createPerson', async () => {
         const uuid = new UUIDT().toString()
         const person = await hub.db.createPerson(DateTime.utc(), { userProp: 'propValue' }, team.id, null, true, uuid, [
@@ -107,7 +69,6 @@ describe('postgres parity', () => {
                 properties: '{"userProp":"propValue"}',
                 is_identified: 1,
                 is_deleted: 0,
-                distinct_ids: expect.arrayContaining(['distinct1', 'distinct2']),
                 _timestamp: expect.any(String),
                 _offset: expect.any(Number),
             },
@@ -115,21 +76,24 @@ describe('postgres parity', () => {
         const clickHouseDistinctIds = await hub.db.fetchDistinctIdValues(person, Database.ClickHouse)
         expect(clickHouseDistinctIds).toEqual(['distinct1', 'distinct2'])
 
-        const postgresPerson = await hub.db.fetchPerson(team.id, 'distinct1')
-        expect(postgresPerson).toEqual({
-            id: expect.any(Number),
-            created_at: expect.any(DateTime),
-            properties: {
-                userProp: 'propValue',
+        const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
+        expect(postgresPersons).toEqual([
+            {
+                id: expect.any(Number),
+                created_at: expect.any(DateTime),
+                properties: {
+                    userProp: 'propValue',
+                },
+                team_id: 2,
+                is_user_id: null,
+                is_identified: true,
+                uuid: uuid,
             },
-            team_id: 2,
-            is_user_id: null,
-            is_identified: true,
-            uuid: uuid,
-            distinct_ids: expect.arrayContaining(['distinct1', 'distinct2']),
-        })
+        ])
+        const postgresDistinctIds = await hub.db.fetchDistinctIdValues(person, Database.Postgres)
+        expect(postgresDistinctIds).toEqual(['distinct1', 'distinct2'])
 
-        expect(person).toEqual(postgresPerson)
+        expect(person).toEqual(postgresPersons[0])
     })
 
     test('updatePerson', async () => {
@@ -166,16 +130,11 @@ describe('postgres parity', () => {
         expect(clickHousePersons[0].is_identified).toEqual(1)
         expect(clickHousePersons[0].is_deleted).toEqual(0)
         expect(clickHousePersons[0].properties).toEqual('{"replacedUserProp":"propValue"}')
-        expect(clickHousePersons[0].distinct_ids).toEqual(expect.arrayContaining(['distinct1', 'distinct2']))
 
         // update date and boolean to false
 
         const randomDate = DateTime.utc().minus(100000).setZone('UTC')
-        await hub.db.updatePerson(person, { created_at: randomDate, is_identified: false }, [
-            'distinct1',
-            'distinct2',
-            'distinct3',
-        ])
+        await hub.db.updatePerson(person, { created_at: randomDate, is_identified: false })
 
         await delayUntilEventIngested(async () =>
             (await hub.db.fetchPersons(Database.ClickHouse)).filter((p) => !p.is_identified)
@@ -195,9 +154,6 @@ describe('postgres parity', () => {
             // TODO: get rid of `+ '.000'` by removing the need for ClickHouseSecondPrecision on CH persons
             castTimestampOrNow(randomDate, TimestampFormat.ClickHouseSecondPrecision) + '.000'
         )
-        expect(clickHousePersons2[0].distinct_ids).toEqual(
-            expect.arrayContaining(['distinct1', 'distinct2', 'distinct3'])
-        )
     })
 
     test('addDistinctId', async () => {
@@ -216,7 +172,7 @@ describe('postgres parity', () => {
             ['another_distinct_id']
         )
         await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
-        const postgresPerson = (await hub.db.fetchPerson(team.id, 'distinct1'))!
+        const [postgresPerson] = await hub.db.fetchPersons(Database.Postgres)
 
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(postgresPerson, Database.ClickHouse), 1)
         const clickHouseDistinctIdValues = await hub.db.fetchDistinctIdValues(postgresPerson, Database.ClickHouse)

--- a/tests/shared/db.test.ts
+++ b/tests/shared/db.test.ts
@@ -1,6 +1,7 @@
 import { Hub, PropertyOperator } from '../../src/types'
 import { DB } from '../../src/utils/db/db'
 import { createHub } from '../../src/utils/db/hub'
+import { ActionManager } from '../../src/worker/ingestion/action-manager'
 import { resetTestDatabase } from '../helpers/sql'
 
 describe('DB', () => {

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -3,16 +3,7 @@ import * as IORedis from 'ioredis'
 import { DateTime } from 'luxon'
 import { performance } from 'perf_hooks'
 
-import {
-    Database,
-    Event,
-    Hub,
-    LogLevel,
-    Person,
-    PersonWithDistinctIds,
-    PluginsServerConfig,
-    Team,
-} from '../../src/types'
+import { Database, Event, Hub, LogLevel, Person, PluginsServerConfig, Team } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 import { hashElements } from '../../src/utils/db/utils'
 import { posthog } from '../../src/utils/posthog'
@@ -52,7 +43,7 @@ async function createPerson(
     team: Team,
     distinctIds: string[],
     properties: Record<string, any> = {}
-): Promise<PersonWithDistinctIds> {
+): Promise<Person> {
     return server.db.createPerson(DateTime.utc(), properties, team.id, null, false, new UUIDT().toString(), distinctIds)
 }
 
@@ -180,8 +171,7 @@ export const createProcessEventTests = (
         }
 
         expect((await hub.db.fetchPersons()).length).toEqual(2)
-        const person0 = (await hub.db.fetchPerson(team.id, 'person_0'))!
-        const person1 = (await hub.db.fetchPerson(team.id, 'person_1'))!
+        const [person0, person1] = await hub.db.fetchPersons()
 
         await eventsProcessor.mergePeople(person0, person1)
 

--- a/tests/worker/ingestion/ingest-event.test.ts
+++ b/tests/worker/ingestion/ingest-event.test.ts
@@ -112,7 +112,8 @@ describe('ingestEvent', () => {
                     is_user_id: null,
                     is_identified: false,
                     uuid: expect.any(String),
-                    distinct_ids: ['abc'],
+                    persondistinctid__team_id: 2,
+                    persondistinctid__distinct_id: 'abc',
                 },
             },
         }


### PR DESCRIPTION
Reverts PostHog/plugin-server#507

This seems to be causing this sentry issue: https://sentry.io/organizations/posthog/issues/2279241522/?project=5592816&query=&statsPeriod=24h
Related discussion: PostHog/product-internal#114

Additionally we got most of the measurements we wanted out of this.

Needs to be deployed together with https://github.com/PostHog/posthog/pull/5354