### PR TITLE
Add API extension

### DIFF
--- a/jest.setup.fetch-mock.js
+++ b/jest.setup.fetch-mock.js
@@ -6,6 +6,7 @@ jest.mock('node-fetch', () => {
     const responsesToUrls = {
         'https://google.com/results.json?query=fetched': { count: 2, query: 'bla', results: [true, true] },
         'https://mmdb.posthog.net/': readFileSync(join(__dirname, 'tests', 'assets', 'GeoLite2-City-Test.mmdb.br')),
+        'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2': { hello: 'world' },
     }
     const headersToUrls = {
         'https://mmdb.posthog.net/': new Map([
@@ -14,12 +15,13 @@ jest.mock('node-fetch', () => {
         ]),
     }
     return jest.fn(
-        (url) =>
+        (url, options) =>
             new Promise((resolve) =>
                 resolve({
                     buffer: () => new Promise((resolve) => resolve(responsesToUrls[url]) || Buffer.from('fetchmock')),
                     json: () => new Promise((resolve) => resolve(responsesToUrls[url]) || { fetch: 'mock' }),
                     text: () => new Promise((resolve) => resolve(JSON.stringify(responsesToUrls[url])) || 'fetchmock'),
+                    status: () => (options.method === 'PUT' ? 201 : 200),
                     headers: headersToUrls[url],
                 })
             )

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ import { HookCommander } from './worker/ingestion/hooks'
 import { OrganizationManager } from './worker/ingestion/organization-manager'
 import { EventsProcessor } from './worker/ingestion/process-event'
 import { TeamManager } from './worker/ingestion/team-manager'
+import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
 import { LazyPluginVM } from './worker/vm/lazy'
 
 export enum LogLevel {
@@ -129,6 +130,7 @@ export interface Hub extends PluginsServerConfig {
     // tools
     teamManager: TeamManager
     organizationManager: OrganizationManager
+    pluginsApiKeyManager: PluginsApiKeyManager
     actionManager: ActionManager
     actionMatcher: ActionMatcher
     hookCannon: HookCommander

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -74,6 +74,28 @@ export interface ParsedLogEntry {
     instance_id: string
 }
 
+export interface CreateUserPayload {
+    uuid: UUIDT
+    password: string
+    first_name: string
+    last_name: string
+    email: string
+    distinct_id: string
+    is_staff: boolean
+    is_active: boolean
+    date_joined: Date
+    events_column_config: Record<string, string> | null
+    organization_id?: RawOrganization['id']
+}
+
+export interface CreatePersonalApiKeyPayload {
+    id: string
+    user_id: number
+    label: string
+    value: string
+    created_at: Date
+}
+
 /** The recommended way of accessing the database. */
 export class DB {
     /** Postgres connection pool for primary database access. */
@@ -983,5 +1005,60 @@ export class DB {
 
     public async deleteRestHook(hookId: Hook['id']): Promise<void> {
         await this.postgresQuery(`DELETE FROM ee_hook WHERE id = $1`, [hookId], 'deleteRestHook')
+    }
+
+    public async createUser({
+        uuid,
+        password,
+        first_name,
+        last_name,
+        email,
+        distinct_id,
+        is_staff,
+        is_active,
+        date_joined,
+        events_column_config,
+        organization_id,
+    }: CreateUserPayload) {
+        const createUserResult = await this.postgresQuery(
+            `INSERT INTO posthog_user (uuid, password, first_name, last_name, email, distinct_id, is_staff, is_active, date_joined, events_column_config)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id`,
+            [
+                uuid.toString(),
+                password,
+                first_name,
+                last_name,
+                email,
+                distinct_id,
+                is_staff,
+                is_active,
+                date_joined.toISOString(),
+                events_column_config,
+            ],
+            'createUser'
+        )
+
+        if (organization_id) {
+            const now = new Date().toISOString()
+            await this.postgresQuery(
+                `INSERT INTO posthog_organizationmembership (id, organization_id, user_id, level, joined_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6)`,
+                [new UUIDT().toString(), organization_id, createUserResult.rows[0].id, 1, now, now],
+                'createOrganizationMembership'
+            )
+        }
+
+        return createUserResult
+    }
+
+    public async createPersonalApiKey({ id, user_id, label, value, created_at }: CreatePersonalApiKeyPayload) {
+        return await this.postgresQuery(
+            `INSERT INTO posthog_personalapikey (id, user_id, label, value, created_at)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING value`,
+            [id, user_id, label, value, created_at.toISOString()],
+            'createPersonalApiKey'
+        )
     }
 }

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -1040,7 +1040,7 @@ export class DB {
         date_joined,
         events_column_config,
         organization_id,
-    }: CreateUserPayload) {
+    }: CreateUserPayload): Promise<QueryResult> {
         const createUserResult = await this.postgresQuery(
             `INSERT INTO posthog_user (uuid, password, first_name, last_name, email, distinct_id, is_staff, is_active, date_joined, events_column_config)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)

--- a/src/utils/db/hub.ts
+++ b/src/utils/db/hub.ts
@@ -6,7 +6,6 @@ import { StatsD } from 'hot-shots'
 import Redis from 'ioredis'
 import { Kafka, logLevel } from 'kafkajs'
 import { DateTime } from 'luxon'
-import * as schedule from 'node-schedule'
 import * as path from 'path'
 import { types as pgTypes } from 'pg'
 import { ConnectionOptions } from 'tls'
@@ -24,6 +23,7 @@ import { InternalMetrics } from '../internal-metrics'
 import { killProcess } from '../kill'
 import { status } from '../status'
 import { createPostgresPool, createRedis, logOrThrowJobQueueError, UUIDT } from '../utils'
+import { PluginsApiKeyManager } from './../../worker/vm/extensions/helpers/api-key-manager'
 import { PluginMetricsManager } from './../plugin-metrics'
 import { DB } from './db'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
@@ -161,6 +161,7 @@ export async function createHub(
     const db = new DB(postgres, redisPool, kafkaProducer, clickhouse, statsd)
     const teamManager = new TeamManager(db)
     const organizationManager = new OrganizationManager(db)
+    const pluginsApiKeyManager = new PluginsApiKeyManager(db)
     const actionManager = new ActionManager(db)
     await actionManager.prepare()
 
@@ -186,6 +187,7 @@ export async function createHub(
 
         teamManager,
         organizationManager,
+        pluginsApiKeyManager,
         actionManager,
         actionMatcher: new ActionMatcher(db, actionManager, statsd),
         hookCannon: new HookCommander(db, teamManager, organizationManager, statsd),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -649,3 +649,54 @@ export class IllegalOperationError extends Error {
         super(operation)
     }
 }
+
+export function getByAge<K, V>(cache: Map<K, [V, number]>, key: K, maxAgeMs = 30_000): V | undefined {
+    if (cache.has(key)) {
+        const [value, age] = cache.get(key)!
+        if (Date.now() - age <= maxAgeMs) {
+            return value
+        }
+    }
+    return undefined
+}
+
+// Equivalent of Python's string.ascii_letters
+export function getAsciiLetters() {
+    const LOWERCASE_START_POINT = 97 // ASCII 'a'
+    const UPPERCASE_START_POINT = 65 // ASCII 'A'
+
+    const lowercaseLetters = Array.from({ length: 26 }).map((_, i) => String.fromCharCode(LOWERCASE_START_POINT + i))
+    const uppercaseLetters = Array.from({ length: 26 }).map((_, i) => String.fromCharCode(UPPERCASE_START_POINT + i))
+
+    return `${lowercaseLetters.join('')}${uppercaseLetters.join('')}`
+}
+
+// Equivalent of Python's string.digits
+export function getAllDigits() {
+    return Array.from({ length: 10 })
+        .map((_, i) => i)
+        .join('')
+}
+
+export function generateRandomToken(nBytes: number) {
+    return intToBase(Number.parseInt(randomBytes(nBytes).toString('hex'), 16), 62)
+}
+
+export function intToBase(num: number, base: number): string {
+    if (base > 62) {
+        throw new IllegalOperationError('Cannot convert integer to base above 62')
+    }
+    const alphabet = getAllDigits() + getAsciiLetters()
+    if (num < 0) {
+        return '-' + intToBase(-num, base)
+    }
+    let value = ''
+    while (num != 0) {
+        const oldNum = num
+        num = Math.floor(oldNum / alphabet.length)
+        const index = oldNum % alphabet.length
+        value = alphabet[index] + value
+    }
+
+    return value || '0'
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -661,7 +661,7 @@ export function getByAge<K, V>(cache: Map<K, [V, number]>, key: K, maxAgeMs = 30
 }
 
 // Equivalent of Python's string.ascii_letters
-export function getAsciiLetters() {
+export function getAsciiLetters(): string {
     const LOWERCASE_START_POINT = 97 // ASCII 'a'
     const UPPERCASE_START_POINT = 65 // ASCII 'A'
 
@@ -672,13 +672,13 @@ export function getAsciiLetters() {
 }
 
 // Equivalent of Python's string.digits
-export function getAllDigits() {
+export function getAllDigits(): string {
     return Array.from({ length: 10 })
         .map((_, i) => i)
         .join('')
 }
 
-export function generateRandomToken(nBytes: number) {
+export function generateRandomToken(nBytes: number): string {
     return intToBase(Number.parseInt(randomBytes(nBytes).toString('hex'), 16), 62)
 }
 
@@ -699,10 +699,4 @@ export function intToBase(num: number, base: number): string {
     }
 
     return value || '0'
-}
-
-// helps make certain conditionals cleaner and more readable, like:
-// !!maybeTruthy === !!alsoMaybeTruthy
-export function isTruthy(value: any): boolean {
-    return !!value
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -700,3 +700,9 @@ export function intToBase(num: number, base: number): string {
 
     return value || '0'
 }
+
+// helps make certain conditionals cleaner and more readable, like:
+// !!maybeTruthy === !!alsoMaybeTruthy
+export function isTruthy(value: any): boolean {
+    return !!value
+}

--- a/src/worker/ingestion/organization-manager.ts
+++ b/src/worker/ingestion/organization-manager.ts
@@ -1,6 +1,7 @@
 import { RawOrganization } from '../../types'
 import { DB } from '../../utils/db/db'
 import { timeoutGuard } from '../../utils/db/utils'
+import { getByAge } from '../../utils/utils'
 
 type OrganizationCache<T> = Map<RawOrganization['id'], [T, number]>
 
@@ -14,7 +15,7 @@ export class OrganizationManager {
     }
 
     public async fetchOrganization(organizationId: RawOrganization['id']): Promise<RawOrganization | null> {
-        const cachedOrganization = this.getByAge(this.organizationCache, organizationId)
+        const cachedOrganization = getByAge(this.organizationCache, organizationId)
         if (cachedOrganization) {
             return cachedOrganization
         }
@@ -27,15 +28,5 @@ export class OrganizationManager {
         } finally {
             clearTimeout(timeout)
         }
-    }
-
-    private getByAge<K, V>(cache: Map<K, [V, number]>, key: K, maxAgeMs = 30_000): V | undefined {
-        if (cache.has(key)) {
-            const [value, age] = cache.get(key)!
-            if (Date.now() - age <= maxAgeMs) {
-                return value
-            }
-        }
-        return undefined
     }
 }

--- a/src/worker/ingestion/team-manager.ts
+++ b/src/worker/ingestion/team-manager.ts
@@ -4,7 +4,7 @@ import { Team, TeamId } from '../../types'
 import { DB } from '../../utils/db/db'
 import { timeoutGuard } from '../../utils/db/utils'
 import { posthog } from '../../utils/posthog'
-import { UUIDT } from '../../utils/utils'
+import { getByAge, UUIDT } from '../../utils/utils'
 
 type TeamCache<T> = Map<TeamId, [T, number]>
 
@@ -22,7 +22,7 @@ export class TeamManager {
     }
 
     public async fetchTeam(teamId: number): Promise<Team | null> {
-        const cachedTeam = this.getByAge(this.teamCache, teamId)
+        const cachedTeam = getByAge(this.teamCache, teamId)
         if (cachedTeam) {
             return cachedTeam
         }
@@ -120,15 +120,5 @@ export class TeamManager {
             eventPropertiesCache = new Set(eventProperties.rows.map((r) => r.name))
             this.eventPropertiesCache.set(teamId, eventPropertiesCache)
         }
-    }
-
-    private getByAge<K, V>(cache: Map<K, [V, number]>, key: K, maxAgeMs = 30_000): V | undefined {
-        if (cache.has(key)) {
-            const [value, age] = cache.get(key)!
-            if (Date.now() - age <= maxAgeMs) {
-                return value
-            }
-        }
-        return undefined
     }
 }

--- a/src/worker/vm/extensions/api.ts
+++ b/src/worker/vm/extensions/api.ts
@@ -1,0 +1,74 @@
+import fetch, { Response } from 'node-fetch'
+
+import { Hub, PluginConfig } from '../../../types'
+
+const DEFAULT_API_HOST = 'https://app.posthog.com'
+
+interface ApiMethodOptions {
+    data: Record<string, any>
+    host: string
+}
+
+export interface ApiExtension {
+    get(path: string, options?: ApiMethodOptions): Promise<Response>
+    post(path: string, options?: ApiMethodOptions): Promise<Response>
+    put(path: string, options?: ApiMethodOptions): Promise<Response>
+    delete(path: string, options?: ApiMethodOptions): Promise<Response>
+}
+
+enum ApiMethod {
+    Get = 'GET',
+    Post = 'POST',
+    Put = 'PUT',
+    Delete = 'DELETE',
+}
+
+export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension {
+    const sendRequest = async (path: string, method: ApiMethod, options?: ApiMethodOptions): Promise<Response> => {
+        let host = options && options.host ? options.host : DEFAULT_API_HOST
+        if (path.startsWith('/')) {
+            path = path.slice(1)
+        }
+        if (host.endsWith('/')) {
+            host = host.slice(0, host.length - 1)
+        }
+        const team = await server.teamManager.fetchTeam(pluginConfig.team_id)
+        if (!team) {
+            throw new Error('Unable to determine project')
+        }
+        const tokenParam = { token: team.api_token }
+        const urlParams = new URLSearchParams(
+            method === (ApiMethod.Get || ApiMethod.Delete) && options && options.data
+                ? { ...options.data, ...tokenParam }
+                : tokenParam
+        )
+        const url = `${host}/${path}?${urlParams.toString()}`
+        const apiKey = await server.pluginsApiKeyManager.fetchPluginsPersonalApiKey(team.organization_id)
+        const headers = { Authorization: `Bearer ${apiKey}` }
+
+        if (method === ApiMethod.Delete || method === ApiMethod.Get) {
+            return await fetch(url, { headers, method })
+        }
+
+        return await fetch(url, {
+            headers,
+            method,
+            body: JSON.stringify(options?.data || {}),
+        })
+    }
+
+    return {
+        get: async (path, options) => {
+            return await sendRequest(path, ApiMethod.Get, options)
+        },
+        post: async (path, options) => {
+            return await sendRequest(path, ApiMethod.Post, options)
+        },
+        put: async (path, options) => {
+            return await sendRequest(path, ApiMethod.Put, options)
+        },
+        delete: async (path, options) => {
+            return await sendRequest(path, ApiMethod.Delete, options)
+        },
+    }
+}

--- a/src/worker/vm/extensions/helpers/api-key-manager.ts
+++ b/src/worker/vm/extensions/helpers/api-key-manager.ts
@@ -16,7 +16,7 @@ export class PluginsApiKeyManager {
         this.pluginsApiKeyCache = new Map()
     }
 
-    public async fetchPluginsPersonalApiKey(organizationId: RawOrganization['id']): Promise<string | null> {
+    public async fetchPluginsPersonalApiKey(organizationId: RawOrganization['id']): Promise<string> {
         const createNewKey = async (userId: number) => {
             return (
                 await this.db.createPersonalApiKey({
@@ -77,7 +77,12 @@ export class PluginsApiKeyManager {
                 }
             }
 
+            if (!key) {
+                throw new Error('Unable to find or create a Personal API Key')
+            }
+
             this.pluginsApiKeyCache.set(organizationId, [key, Date.now()])
+
             return key
         } finally {
             clearTimeout(timeout)

--- a/src/worker/vm/extensions/helpers/api-key-manager.ts
+++ b/src/worker/vm/extensions/helpers/api-key-manager.ts
@@ -38,7 +38,7 @@ export class PluginsApiKeyManager {
         try {
             let key: string | null = null
             const userResult = await this.db.postgresQuery(
-                `SELECT id FROM posthog_user WHERE email = '$1'`,
+                `SELECT id FROM posthog_user WHERE email = $1`,
                 [PLUGINS_API_KEY_USER_EMAIL],
                 'fetchPluginsUser'
             )

--- a/src/worker/vm/extensions/helpers/api-key-manager.ts
+++ b/src/worker/vm/extensions/helpers/api-key-manager.ts
@@ -1,0 +1,86 @@
+import { DB } from '../../../../utils/db/db'
+import { timeoutGuard } from '../../../../utils/db/utils'
+import { generateRandomToken, getByAge, UUIDT } from '../../../../utils/utils'
+import { RawOrganization } from './../../../../types'
+
+type PluginsApiKeyCache<T> = Map<RawOrganization['id'], [T, number]>
+
+const PLUGINS_API_KEY_USER_EMAIL = '$plugins_personal_api_key'
+
+export class PluginsApiKeyManager {
+    db: DB
+    pluginsApiKeyCache: PluginsApiKeyCache<string | null>
+
+    constructor(db: DB) {
+        this.db = db
+        this.pluginsApiKeyCache = new Map()
+    }
+
+    public async fetchPluginsPersonalApiKey(organizationId: RawOrganization['id']): Promise<string | null> {
+        const createNewKey = async (userId: number) => {
+            return (
+                await this.db.createPersonalApiKey({
+                    id: generateRandomToken(32),
+                    user_id: userId,
+                    label: 'autogen',
+                    value: `phx_${generateRandomToken(32)}`,
+                    created_at: new Date(),
+                })
+            ).rows[0].value
+        }
+
+        const cachedKey = getByAge(this.pluginsApiKeyCache, organizationId)
+        if (cachedKey) {
+            return cachedKey
+        }
+
+        const timeout = timeoutGuard(`Still running "fetchPluginsPersonalApiKey". Timeout warning after 30 sec!`)
+        try {
+            let key: string | null = null
+            const userResult = await this.db.postgresQuery(
+                `SELECT id FROM posthog_user WHERE email = '${PLUGINS_API_KEY_USER_EMAIL}'`,
+                [],
+                'fetchPluginsUser'
+            )
+
+            if (userResult.rowCount < 1) {
+                // No user yet, provision a user and a key
+                const newUserResult = await this.db.createUser({
+                    uuid: new UUIDT(),
+                    password: generateRandomToken(32),
+                    first_name: 'Plugins API User [Bot]',
+                    last_name: '',
+                    email: PLUGINS_API_KEY_USER_EMAIL,
+                    distinct_id: generateRandomToken(32),
+                    is_staff: false,
+                    is_active: true,
+                    date_joined: new Date(),
+                    events_column_config: { active: 'DEFAULT' },
+                    organization_id: organizationId,
+                })
+
+                key = await createNewKey(newUserResult.rows[0].id)
+            } else {
+                // User exists, check if the key does too
+                const userId = userResult.rows[0].id
+                const personalApiKeyResult = await this.db.postgresQuery(
+                    'SELECT value FROM posthog_personalapikey WHERE user_id = $1',
+                    [userId],
+                    'fetchPluginsPersonalApiKey'
+                )
+
+                // user remains but key was somehow deleted
+                if (!personalApiKeyResult.rows.length || !personalApiKeyResult.rows[0].value) {
+                    key = await createNewKey(userId)
+                } else {
+                    key = personalApiKeyResult.rows[0].value
+                }
+            }
+
+            this.pluginsApiKeyCache.set(organizationId, [key, Date.now()])
+            return key
+        } finally {
+            clearTimeout(timeout)
+        }
+    }
+}

--- a/src/worker/vm/extensions/posthog.ts
+++ b/src/worker/vm/extensions/posthog.ts
@@ -4,9 +4,9 @@ import { Hub, PluginConfig, RawEventMessage } from 'types'
 
 import { Client } from '../../../utils/celery/client'
 import { UUIDT } from '../../../utils/utils'
+import { ApiExtension, createApi } from './api'
 
 const { version } = require('../../../../package.json')
-
 interface InternalData {
     distinct_id: string
     event: string
@@ -18,6 +18,7 @@ interface InternalData {
 
 export interface DummyPostHog {
     capture(event: string, properties?: Record<string, any>): void
+    api: ApiExtension
 }
 
 export function createPosthog(server: Hub, pluginConfig: PluginConfig): DummyPostHog {
@@ -81,5 +82,6 @@ export function createPosthog(server: Hub, pluginConfig: PluginConfig): DummyPos
             }
             sendEvent(data)
         },
+        api: createApi(server, pluginConfig),
     }
 }

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -165,6 +165,7 @@ export async function createUserTeamAndOrganization(
         setup_section_2_completed: true,
         for_internal_metrics: false,
         available_features: [],
+        domain_whitelist: [],
     } as RawOrganization)
     await insertRow(db, 'posthog_organizationmembership', {
         id: organizationMembershipId,

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -698,6 +698,71 @@ test('fetch via require', async () => {
     expect(event.properties).toEqual({ count: 2, query: 'bla', results: [true, true] })
 })
 
+test('posthog.api', async () => {
+    const indexJs = `
+        async function processEvent (event, meta) {
+            event.properties = {}
+            const getResponse = await posthog.api.get('/api/event')
+            event.properties.get = await getResponse.json()
+            await posthog.api.get('/api/event', { data: { url: 'param' } })
+            await posthog.api.post('/api/event', { data: { a: 1 }})
+            await posthog.api.put('/api/event', { data: { b: 2 } })
+            await posthog.api.delete('/api/event')
+            return event
+        }
+    `
+    await resetTestDatabase(indexJs)
+    const vm = await createPluginConfigVM(hub, pluginConfig39, indexJs)
+    const event: PluginEvent = {
+        ...defaultEvent,
+        event: 'fetched',
+    }
+
+    await vm.methods.processEvent!(event)
+
+    expect(event.properties?.get).toEqual({ hello: 'world' })
+    expect((fetch as any).mock.calls.length).toEqual(5)
+    expect((fetch as any).mock.calls).toEqual([
+        [
+            'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+            {
+                headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                method: 'GET',
+            },
+        ],
+        [
+            'https://app.posthog.com/api/event?url=param&token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+            {
+                headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                method: 'GET',
+            },
+        ],
+        [
+            'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+            {
+                headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                method: 'POST',
+                body: JSON.stringify({ a: 1 }),
+            },
+        ],
+        [
+            'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+            {
+                headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                method: 'PUT',
+                body: JSON.stringify({ b: 2 }),
+            },
+        ],
+        [
+            'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+            {
+                headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                method: 'DELETE',
+            },
+        ],
+    ])
+})
+
 test('attachments', async () => {
     const indexJs = `
         async function processEvent (event, meta) {

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -708,6 +708,9 @@ test('posthog.api', async () => {
             await posthog.api.post('/api/event', { data: { a: 1 }})
             await posthog.api.put('/api/event', { data: { b: 2 } })
             await posthog.api.delete('/api/event')
+
+            // test auth defaults override
+            await posthog.api.get('/api/event', { projectApiKey: 'token', personalApiKey: 'secret' })
             return event
         }
     `
@@ -721,7 +724,7 @@ test('posthog.api', async () => {
     await vm.methods.processEvent!(event)
 
     expect(event.properties?.get).toEqual({ hello: 'world' })
-    expect((fetch as any).mock.calls.length).toEqual(5)
+    expect((fetch as any).mock.calls.length).toEqual(6)
     expect((fetch as any).mock.calls).toEqual([
         [
             'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
@@ -758,6 +761,13 @@ test('posthog.api', async () => {
             {
                 headers: { Authorization: expect.stringContaining('Bearer phx_') },
                 method: 'DELETE',
+            },
+        ],
+        [
+            'https://app.posthog.com/api/event?token=token',
+            {
+                headers: { Authorization: 'Bearer secret' },
+                method: 'GET',
             },
         ],
     ])


### PR DESCRIPTION
## Changes

This allows plugin devs to access the PostHog API with a lot more ease and security than right now.

This is now possible, for example:

```js
await posthog.api.get('/api/event')
```

Currently, devs have to do all the fetch requests themselves, meaning they also need to ask the user for a Personal API Key. We have a frontend mechanism to automatically provision one if you name your config option `posthogApiKey`, but this really isn't great. 

Not only that, but after https://github.com/PostHog/posthog/pull/5044, devs now should also specify a project to ensure they're accessing the right data. The token for this could be pulled from events, but what about plugins that only use e.g. `runEveryMinute` and access API, like the GitHub, GitLab, and Bitbucket annotators?

I originally set out to just build a simple way for devs to access the project token, but then I figured there's a lot more help we can give them here.

Admittedly, this isn't the nicest solution. What I'd like is a secret project token, but I have been convinced by others that dummy users might be the simplest way to go about this as of right now.

Hence, this mechanism provisions a "bot" user for the org in which the plugin using the API is enabled and a personal API key for this user, using this to execute any API requests. No need to ask users for personal API keys nor project tokens.

## Potential Additions

Having started to write this description, I realized it would probably be best to allow overriding the personal API key and the project token, so users can also access other PostHog instances/teams this way, but with the default behavior always being scoped to their specific team, to prevent unintended operations.

Also needs some good docs.