### PR TITLE
Capture handleIdentifyOrAlias exceptions in Sentry

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -100,6 +100,8 @@ export class EventsProcessor {
             })
             try {
                 await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
+            } catch (e) {
+                Sentry.captureException(e)
             } finally {
                 clearTimeout(timeout1)
             }

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -101,6 +101,7 @@ export class EventsProcessor {
             try {
                 await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
             } catch (e) {
+                console.error('handleIdentifyOrAlias failed', e, data)
                 Sentry.captureException(e, { extra: { event: data } })
             } finally {
                 clearTimeout(timeout1)

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -101,7 +101,7 @@ export class EventsProcessor {
             try {
                 await this.handleIdentifyOrAlias(data['event'], properties, distinctId, teamId)
             } catch (e) {
-                Sentry.captureException(e)
+                Sentry.captureException(e, { extra: { event: data } })
             } finally {
                 clearTimeout(timeout1)
             }

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -166,6 +166,7 @@ export async function createUserTeamAndOrganization(
         for_internal_metrics: false,
         available_features: [],
         domain_whitelist: [],
+        is_member_join_email_enabled: false,
     } as RawOrganization)
     await insertRow(db, 'posthog_organizationmembership', {
         id: organizationMembershipId,


### PR DESCRIPTION
## Changes

I can confirm that `handleIdentifyOrAlias` **does** throw in certain conditions. We're just not doing anything when that happens. 

This will be important to more precisely identify the most common race conditions affecting us.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
