### PR TITLE
Handle moveDistinctIds race conditions

### DIFF
--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -44,6 +44,7 @@ import {
     castTimestampOrNow,
     clickHouseTimestampToISO,
     escapeClickHouseString,
+    RaceConditionError,
     sanitizeSqlIdentifier,
     tryTwice,
     UUID,
@@ -605,7 +606,7 @@ export class DB {
         // this is caused by a race condition and will trigger a retry with
         // updated persons
         if (movedDistinctIdResult.rows.length === 0) {
-            throw new Error(`Failed trying to move distinct IDs because otherPerson doesn't exist.`)
+            throw new RaceConditionError(`Failed trying to move distinct IDs because otherPerson doesn't exist.`)
         }
 
         if (this.kafkaProducer) {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -604,7 +604,7 @@ export class DB {
 
         // this is caused by a race condition and will trigger a retry
         if (movedDistinctIdResult.rows.length === 0) {
-            throw new Error('Tried to move ditinct IDs from a non-existent person')
+            throw new Error('Tried to move ditinct IDs from an unreferenced person')
         }
 
         if (this.kafkaProducer) {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -602,9 +602,10 @@ export class DB {
             'updateDistinctIdPerson'
         )
 
-        // this is caused by a race condition and will trigger a retry
+        // this is caused by a race condition and will trigger a retry with
+        // updated persons
         if (movedDistinctIdResult.rows.length === 0) {
-            throw new Error('Tried to move ditinct IDs from an unreferenced person')
+            throw new Error(`Failed trying to move distinct IDs because otherPerson doesn't exist.`)
         }
 
         if (this.kafkaProducer) {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -602,6 +602,11 @@ export class DB {
             'updateDistinctIdPerson'
         )
 
+        // this is caused by a race condition and will trigger a retry
+        if (movedDistinctIdResult.rows.length === 0) {
+            throw new Error('Tried to move ditinct IDs from a non-existent person')
+        }
+
         if (this.kafkaProducer) {
             for (const row of movedDistinctIdResult.rows) {
                 await this.kafkaProducer.queueMessage({

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -649,3 +649,9 @@ export class IllegalOperationError extends Error {
         super(operation)
     }
 }
+
+// For errors we want to explicitly throw
+// concerning race conditions across threads
+export class RaceConditionError extends Error {
+    name = 'RaceConditionError'
+}

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -377,7 +377,7 @@ export class EventsProcessor {
             } catch (error) {
                 Sentry.captureException(error, { extra: { mergeIntoPayload, otherPersonPayload } })
 
-                // If the a person was deleted in between fetching and moveDistinctId,
+                // If a person was deleted in between fetching and moveDistinctId,
                 // try to fetch the person again as the distinct ID is likely to now point
                 // to another person
                 const otherPersonResult = await this.db.fetchPerson(teamId, mergeIntoDistinctId)

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -173,7 +173,13 @@ export const createProcessEventTests = (
         expect((await hub.db.fetchPersons()).length).toEqual(2)
         const [person0, person1] = await hub.db.fetchPersons()
 
-        await eventsProcessor.mergePeople([person0, 'person_0'], [person1, 'person_1'])
+        await eventsProcessor.mergePeople({
+            mergeInto: person0,
+            mergeIntoDistinctId: 'person_0',
+            otherPerson: person1,
+            otherPersonDistinctId: 'person_1',
+            totalMergeAttempts: 0,
+        })
 
         if (database === 'clickhouse') {
             await delayUntilEventIngested(async () =>

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -173,7 +173,7 @@ export const createProcessEventTests = (
         expect((await hub.db.fetchPersons()).length).toEqual(2)
         const [person0, person1] = await hub.db.fetchPersons()
 
-        await eventsProcessor.mergePeople(person0, person1)
+        await eventsProcessor.mergePeople([person0, 'person_0'], [person1, 'person_1'])
 
         if (database === 'clickhouse') {
             await delayUntilEventIngested(async () =>


### PR DESCRIPTION
## Changes

Me and @macobo will probably discuss this a bit further tomorrow.

Handles 2 types of race conditions that may arise when running `mergeDistinctIds`:

- `mergeInto` person no longer exists: this triggers [an error](https://sentry.io/organizations/posthog/issues/2454986618/?project=5592816&query=is%3Aunresolved+pg&statsPeriod=14d) and leaves the persons unmerged
- `otherPerson` no longer exists: this currently does not trigger an error but leaves persons unmerged

These happen because in between the time the persons are fetched and `moveDistinctIds` is called, another thread may have deleted either of the persons. Happy to explain further. 

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
