### PR TITLE
nicer handling of insert distinct id failure

### DIFF
--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -570,9 +570,14 @@ export class DB {
         distinctId: string
     ): Promise<ProducerRecord | void> {
         const insertResult = await client.query(
-            'INSERT INTO posthog_persondistinctid (distinct_id, person_id, team_id) VALUES ($1, $2, $3) RETURNING *',
+            'INSERT INTO posthog_persondistinctid (distinct_id, person_id, team_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING RETURNING *',
             [distinctId, person.id, person.team_id]
         )
+
+        // some other thread already added this ID
+        if (insertResult.rows.length === 0) {
+            return
+        }
 
         const personDistinctIdCreated = insertResult.rows[0] as PersonDistinctId
         if (this.kafkaProducer) {

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -291,7 +291,8 @@ export class EventsProcessor {
             try {
                 await this.db.addDistinctId(oldPerson, distinctId)
                 // Catch race case when somebody already added this distinct_id between .get and .addDistinctId
-            } catch {
+            } catch (error) {
+                Sentry.captureException(error)
                 // integrity error
                 if (retryIfFailed) {
                     // run everything again to merge the users if needed
@@ -305,7 +306,8 @@ export class EventsProcessor {
             try {
                 await this.db.addDistinctId(newPerson, previousDistinctId)
                 // Catch race case when somebody already added this distinct_id between .get and .addDistinctId
-            } catch {
+            } catch (error) {
+                Sentry.captureException(error)
                 // integrity error
                 if (retryIfFailed) {
                     // run everything again to merge the users if needed
@@ -321,7 +323,8 @@ export class EventsProcessor {
                     distinctId,
                     previousDistinctId,
                 ])
-            } catch {
+            } catch (error) {
+                Sentry.captureException(error)
                 // Catch race condition where in between getting and creating,
                 // another request already created this person
                 if (retryIfFailed) {


### PR DESCRIPTION
## Changes

I did some digging and turns out Postgres errors like 20-40 times per minute trying to insert a distinct ID that already exists. More context on #526 

The plugin server handles this properly yet it swallows the errors, while Postgres creates a bit of logspam for what is an expected error for our system. This is similar to #523

Ultimately, this means that on Cloud we're doing tens of thousands of unnecessary queries a day just for distinct ID inserts, but I think any potential solution at this stage might just be over-engineering and would still be prone to race conditons, even if it shortens the window for them to happen.

Anyway, so this just silences unnecessary Postgres errors while making sure the errors we do care about are actually captured in Sentry.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
