### PR TITLE
Improve kafka distinct_id messages

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -489,7 +489,6 @@ export interface PersonDistinctId {
 
 /** ClickHouse PersonDistinctId model. */
 export interface ClickHousePersonDistinctId {
-    id: number
     team_id: number
     person_id: string
     distinct_id: string

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -657,16 +657,20 @@ export class DB {
 
         if (this.kafkaProducer) {
             for (const row of movedDistinctIdResult.rows) {
+                const { id, ...usefulColumns } = row
                 await this.kafkaProducer.queueMessage({
                     topic: KAFKA_PERSON_UNIQUE_ID,
                     messages: [
-                        { value: Buffer.from(JSON.stringify({ ...row, person_id: target.uuid, is_deleted: 0 })) },
-                    ],
-                })
-                await this.kafkaProducer.queueMessage({
-                    topic: KAFKA_PERSON_UNIQUE_ID,
-                    messages: [
-                        { value: Buffer.from(JSON.stringify({ ...row, person_id: source.uuid, is_deleted: 1 })) },
+                        {
+                            value: Buffer.from(
+                                JSON.stringify({ ...usefulColumns, person_id: target.uuid, is_deleted: 0 })
+                            ),
+                        },
+                        {
+                            value: Buffer.from(
+                                JSON.stringify({ ...usefulColumns, person_id: source.uuid, is_deleted: 1 })
+                            ),
+                        },
                     ],
                 })
             }

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -560,7 +560,7 @@ export class DB {
                         WHERE person_id='${escapeClickHouseString(person.uuid)}'
                           AND team_id='${person.team_id}'
                           AND is_deleted=0
-                        ORDER BY id`
+                        ORDER BY _offset`
                 )
             ).data as ClickHousePersonDistinctId[]
         } else if (database === Database.Postgres) {

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -188,7 +188,6 @@ describe('postgres parity', () => {
 
         expect(clickHouseDistinctIds).toEqual([
             {
-                id: expect.any(Number),
                 distinct_id: 'distinct1',
                 person_id: person.uuid,
                 team_id: team.id,
@@ -199,7 +198,6 @@ describe('postgres parity', () => {
         ])
         expect(postgresDistinctIds).toEqual([
             {
-                id: expect.any(Number),
                 distinct_id: 'distinct1',
                 person_id: person.id,
                 team_id: team.id,

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -203,7 +203,15 @@ describe('postgres parity', () => {
                 team_id: team.id,
             }),
         ])
-        expect(clickHouseDistinctIds[0].id).toEqual(postgresDistinctIds[0].id)
+        expect([
+            clickHouseDistinctIds[0].team_id,
+            clickHouseDistinctIds[0].person_id,
+            clickHouseDistinctIds[0].distinct_id,
+        ]).toEqual([
+            postgresDistinctIds[0].team_id,
+            postgresDistinctIds[0].person_id,
+            postgresDistinctIds[0].distinct_id,
+        ])
 
         // add 'anotherOne' to person
 

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -197,11 +197,11 @@ describe('postgres parity', () => {
             },
         ])
         expect(postgresDistinctIds).toEqual([
-            {
+            expect.objectContaining({
                 distinct_id: 'distinct1',
                 person_id: person.id,
                 team_id: team.id,
-            },
+            }),
         ])
         expect(clickHouseDistinctIds[0].id).toEqual(postgresDistinctIds[0].id)
 

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -191,7 +191,7 @@ describe('postgres parity', () => {
                 distinct_id: 'distinct1',
                 person_id: person.uuid,
                 team_id: team.id,
-                is_deleted: 0,
+                _sign: 1,
                 _timestamp: expect.any(String),
                 _offset: expect.any(Number),
             },
@@ -258,8 +258,8 @@ describe('postgres parity', () => {
         const clickHouseDistinctIdValuesMoved = await hub.db.fetchDistinctIdValues(anotherPerson, Database.ClickHouse)
         const postgresDistinctIdValuesMoved = await hub.db.fetchDistinctIdValues(anotherPerson, Database.Postgres)
 
-        expect(clickHouseDistinctIdValuesMoved).toEqual(['distinct1', 'another_distinct_id'])
-        expect(postgresDistinctIdValuesMoved).toEqual(['distinct1', 'another_distinct_id'])
+        expect(clickHouseDistinctIdValuesMoved).toEqual(expect.arrayContaining(['distinct1', 'another_distinct_id']))
+        expect(postgresDistinctIdValuesMoved).toEqual(expect.arrayContaining(['distinct1', 'another_distinct_id']))
 
         // it got removed
 

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -203,15 +203,6 @@ describe('postgres parity', () => {
                 team_id: team.id,
             }),
         ])
-        expect([
-            clickHouseDistinctIds[0].team_id,
-            clickHouseDistinctIds[0].person_id,
-            clickHouseDistinctIds[0].distinct_id,
-        ]).toEqual([
-            postgresDistinctIds[0].team_id,
-            postgresDistinctIds[0].person_id,
-            postgresDistinctIds[0].distinct_id,
-        ])
 
         // add 'anotherOne' to person
 


### PR DESCRIPTION
## Changes

Only call `queueMessage` once, stop passing Postgres row id to CH table

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
