### PR TITLE
Trigger plugin jobs via Celery

### DIFF
--- a/src/main/ingestion-queues/queue.ts
+++ b/src/main/ingestion-queues/queue.ts
@@ -11,7 +11,7 @@ import { KafkaQueue } from './kafka-queue'
 
 interface Queues {
     ingestion: Queue
-    redis: Queue
+    auxiliary: Queue
 }
 
 export function pauseQueueIfWorkerFull(
@@ -57,7 +57,7 @@ export async function startQueues(
         const redisQueue = startQueueRedis(server, piscina, mergedWorkerMethods)
         const queues = {
             ingestion: redisQueue,
-            redis: redisQueue,
+            auxiliary: redisQueue,
         }
         if (server.KAFKA_ENABLED) {
             queues.ingestion = await startQueueKafka(server, piscina, mergedWorkerMethods)

--- a/src/main/ingestion-queues/queue.ts
+++ b/src/main/ingestion-queues/queue.ts
@@ -80,7 +80,7 @@ function startQueueRedis(server: Hub, piscina: Piscina, workerMethods: WorkerMet
                     payload,
                     pluginConfigId,
                     pluginConfigTeam,
-                    timestamp: new Date().getTime(),
+                    timestamp: Date.now(),
                 }
                 await piscina?.run({ task: 'enqueueJob', args: { job } })
             } catch (e) {

--- a/src/main/ingestion-queues/queue.ts
+++ b/src/main/ingestion-queues/queue.ts
@@ -91,6 +91,7 @@ function startQueueRedis(server: Hub, piscina: Piscina, workerMethods: WorkerMet
                     pluginConfigTeam,
                     timestamp: Date.now(),
                 }
+                pauseQueueIfWorkerFull(() => celeryQueue.pause(), server, piscina)
                 await piscina?.run({ task: 'enqueueJob', args: { job } })
             } catch (e) {
                 Sentry.captureException(e)

--- a/src/main/ingestion-queues/queue.ts
+++ b/src/main/ingestion-queues/queue.ts
@@ -49,10 +49,11 @@ export async function startQueue(
     }
 
     try {
+        const redisQueue = startQueueRedis(server, piscina, mergedWorkerMethods)
         if (server.KAFKA_ENABLED) {
             return await startQueueKafka(server, piscina, mergedWorkerMethods)
         }
-        return startQueueRedis(server, piscina, mergedWorkerMethods)
+        return redisQueue
     } catch (error) {
         status.error('💥', 'Failed to start event queue:\n', error)
         throw error

--- a/src/main/pluginsServer.ts
+++ b/src/main/pluginsServer.ts
@@ -49,7 +49,7 @@ export async function startPluginsServer(
     let pluginMetricsJob: schedule.Job | undefined
     let piscina: Piscina | undefined
     let queue: Queue | undefined // ingestion queue
-    let redisQueueForKafkaIngestion: Queue | undefined | null
+    let redisQueueForPluginJobs: Queue | undefined | null
     let jobQueueConsumer: JobQueueConsumerControl | undefined
     let closeHub: () => Promise<void> | undefined
     let scheduleControl: ScheduleControl | undefined
@@ -72,7 +72,7 @@ export async function startPluginsServer(
         status.info('💤', ' Shutting down gracefully...')
         lastActivityCheck && clearInterval(lastActivityCheck)
         await queue?.stop()
-        await redisQueueForKafkaIngestion?.stop()
+        await redisQueueForPluginJobs?.stop()
         await pubSub?.stop()
         actionsReloadJob && schedule.cancelJob(actionsReloadJob)
         pingJob && schedule.cancelJob(pingJob)
@@ -142,12 +142,12 @@ export async function startPluginsServer(
         // have one queue for plugin jobs and ingestion. With Kafka ingestion, we
         // use Kafka for events but still start Redis for plugin jobs.
         // Thus, if Kafka is disabled, we don't need to call anything on
-        // redisQueueForKafkaIngestion, as that will also be the ingestion queue.
+        // redisQueueForPluginJobs, as that will also be the ingestion queue.
         queue = queues.ingestion
-        redisQueueForKafkaIngestion = config.KAFKA_ENABLED ? queues.redis : null
+        redisQueueForPluginJobs = config.KAFKA_ENABLED ? queues.auxiliary : null
         piscina.on('drain', () => {
             void queue?.resume()
-            void redisQueueForKafkaIngestion?.resume()
+            void redisQueueForPluginJobs?.resume()
 
             void jobQueueConsumer?.resume()
         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -686,3 +686,5 @@ export interface PropertyDefinitionType {
 }
 
 export type PluginFunction = 'onEvent' | 'processEvent' | 'onSnapshot' | 'pluginTask'
+
+export type CeleryTriggeredJobOperation = 'start' // new ops go here

--- a/src/types.ts
+++ b/src/types.ts
@@ -686,4 +686,6 @@ export interface PropertyDefinitionType {
 
 export type PluginFunction = 'onEvent' | 'processEvent' | 'onSnapshot' | 'pluginTask'
 
-export type CeleryTriggeredJobOperation = 'start' // new ops go here
+export enum CeleryTriggeredJobOperation {
+    Start = 'start',
+}

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -12,7 +12,6 @@ import {
     Event,
     Hub,
     Person,
-    PersonDistinctId,
     PostgresSessionRecordingEvent,
     SessionRecordingEvent,
     TeamId,

--- a/src/worker/tasks.ts
+++ b/src/worker/tasks.ts
@@ -60,4 +60,7 @@ export const workerTasks: Record<string, TaskRunner> = {
     sendPluginMetrics: (hub) => {
         hub.pluginMetricsManager.sendPluginMetrics(hub)
     },
+    enqueueJob: async (hub, { job }: { job: EnqueuedJob }) => {
+        await hub.jobQueueManager.enqueue(job)
+    },
 }


### PR DESCRIPTION
## Changes

Allows plugin jobs to be triggered via the PostHog UI. This needs a supporting PR to `posthog` that's coming soon.

How it works:

- An endpoint in `posthog` receives the job specs (job name, payload) via a POST request
- The request triggers sending a task to Celery which is picked up by the plugin server
- The plugin server enqueues the job to be run as soon as possible, but still going through the job queues (instead of skipping to `runJob` directly)

A few things were built in on the `posthog` side as well as here that aren't yet natively supported but will help us going forward. The most important of these is the job operation, which is currently just being dumped in the payload if devs want to do anything with it. In the future this will allow us to do things like start and stop longer running jobs like imports and exports. 


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
