### PR TITLE
Remove `id` from `ClickHousePersonDistinctId` interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -489,7 +489,6 @@ export interface PersonDistinctId {
 
 /** ClickHouse PersonDistinctId model. */
 export interface ClickHousePersonDistinctId {
-    id: number
     team_id: number
     person_id: string
     distinct_id: string

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -203,7 +203,15 @@ describe('postgres parity', () => {
                 team_id: team.id,
             }),
         ])
-        expect(clickHouseDistinctIds[0].id).toEqual(postgresDistinctIds[0].id)
+        expect([
+            clickHouseDistinctIds[0].team_id,
+            clickHouseDistinctIds[0].person_id,
+            clickHouseDistinctIds[0].distinct_id,
+        ]).toEqual([
+            postgresDistinctIds[0].team_id,
+            postgresDistinctIds[0].person_id,
+            postgresDistinctIds[0].distinct_id,
+        ])
 
         // add 'anotherOne' to person
 


### PR DESCRIPTION
## Changes

Extension to #536 that fixes the remaining issue.