### PR TITLE
Throw errors on deletePerson transaction

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -1,17 +1,44 @@
+import * as Sentry from '@sentry/node'
 import { StatsD, Tags } from 'hot-shots'
 
 export async function instrumentQuery<T>(
     statsd: StatsD | undefined,
     metricName: string,
     tag: string | undefined,
+    runQuery: () => Promise<T>,
+    throwErrors: boolean
+): Promise<T | void>
+export async function instrumentQuery<T>(
+    statsd: StatsD | undefined,
+    metricName: string,
+    tag: string | undefined,
     runQuery: () => Promise<T>
+): Promise<T>
+export async function instrumentQuery<T>(
+    statsd: StatsD | undefined,
+    metricName: string,
+    tag: string | undefined,
+    runQuery: () => Promise<T>,
+    throwErrors?: boolean
 ): Promise<T> {
     const tags: Tags | undefined = tag ? { queryTag: tag } : undefined
     const timer = new Date()
 
     statsd?.increment(`${metricName}.total`, tags)
+
+    if (!throwErrors) {
+        try {
+            return await runQuery()
+        } finally {
+            statsd?.timing(metricName, timer, tags)
+        }
+    }
+
     try {
         return await runQuery()
+    } catch (error) {
+        Sentry.captureException(error)
+        throw error
     } finally {
         statsd?.timing(metricName, timer, tags)
     }


### PR DESCRIPTION
## Changes

It's pretty late for me and I'm looking into CH duplicate IDs again. Apologies for the somewhat messy solution but this is what I came up with that keeps everything else the same (and types satisfied) while isolating errors for that `deletePerson` transaction particularly so we can quickly roll out a fix.

The TL;DR is that https://github.com/PostHog/plugin-server/pull/202 silenced https://sentry.io/organizations/posthog/issues/2225546229/?project=5592816&query=is%3Aunresolved&statsPeriod=14d which is problematic because we rely on that `deletePerson` transaction throwing if a distinct ID has lingered. See https://github.com/PostHog/plugin-server/blob/e96b0e408e2d53841e791d9db9bc6a488c6bbd44/src/worker/ingestion/process-event.ts#L385

Given `instrumentQuery` silences the error, we never try to merge the person again, and thus can end up not deleting IDs we should delete. 

Happy to explain more, but now, 😴 



## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
