### PR TITLE
Eliminate `PLUGIN_SERVER_ACTION_MATCHING`

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -73,7 +73,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         CRASH_IF_NO_PERSISTENT_JOB_QUEUE: false,
         STALENESS_RESTART_SECONDS: 0,
         CAPTURE_INTERNAL_METRICS: false,
-        PLUGIN_SERVER_ACTION_MATCHING: 2,
         PISCINA_USE_ATOMICS: true,
         PISCINA_ATOMICS_TIMEOUT: 5000,
     }
@@ -127,8 +126,6 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
             'refuse to start unless there is a properly configured persistent job queue (e.g. graphile)',
         STALENESS_RESTART_SECONDS: 'trigger a restart if no event ingested for this duration',
         CAPTURE_INTERNAL_METRICS: 'capture internal metrics for posthog in posthog',
-        PLUGIN_SERVER_ACTION_MATCHING:
-            'whether plugin server action matching results should be used (transition period setting)',
         PISCINA_USE_ATOMICS:
             'corresponds to the piscina useAtomics config option (https://github.com/piscinajs/piscina#constructor-new-piscinaoptions)',
         PISCINA_ATOMICS_TIMEOUT:

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,6 @@ export interface PluginsServerConfig extends Record<string, any> {
     CRASH_IF_NO_PERSISTENT_JOB_QUEUE: boolean
     STALENESS_RESTART_SECONDS: number
     CAPTURE_INTERNAL_METRICS: boolean
-    PLUGIN_SERVER_ACTION_MATCHING: 0 | 1 | 2
     PISCINA_USE_ATOMICS: boolean
     PISCINA_ATOMICS_TIMEOUT: number
 }

--- a/src/worker/ingestion/ingest-event.ts
+++ b/src/worker/ingestion/ingest-event.ts
@@ -23,11 +23,11 @@ export async function ingestEvent(hub: Hub, event: PluginEvent): Promise<IngestE
             sent_at ? DateTime.fromISO(sent_at) : null,
             uuid! // it will throw if it's undefined
         )
-        if (hub.PLUGIN_SERVER_ACTION_MATCHING >= 1 && result) {
+        if (result) {
             const person = await hub.db.fetchPerson(team_id, distinctId)
             const actionMatches = await hub.actionMatcher.match(event, person, result.elements)
             await hub.hookCannon.findAndFireHooks(event, person, site_url, actionMatches)
-            if (hub.PLUGIN_SERVER_ACTION_MATCHING >= 2 && actionMatches.length && result.eventId !== undefined) {
+            if (actionMatches.length && result.eventId !== undefined) {
                 await hub.db.registerActionMatch(result.eventId, actionMatches)
             }
         }

--- a/tests/postgres/e2e.test.ts
+++ b/tests/postgres/e2e.test.ts
@@ -51,7 +51,6 @@ describe('e2e postgres ingestion', () => {
                 CELERY_DEFAULT_QUEUE: 'test-celery-default-queue',
                 LOG_LEVEL: LogLevel.Log,
                 KAFKA_ENABLED: false,
-                PLUGIN_SERVER_ACTION_MATCHING: 2,
             },
             makePiscina
         )

--- a/tests/worker/ingestion/ingest-event.test.ts
+++ b/tests/worker/ingestion/ingest-event.test.ts
@@ -18,7 +18,7 @@ describe('ingestEvent', () => {
 
     beforeEach(async () => {
         await resetTestDatabase()
-        ;[hub, closeServer] = await createHub({ PLUGIN_SERVER_ACTION_MATCHING: 1 })
+        ;[hub, closeServer] = await createHub()
         actionMatcher = hub.actionMatcher
         actionCounter = 0
     })


### PR DESCRIPTION
## Changes

Since https://github.com/PostHog/plugin-server/pull/436 has been rolled out successfully, its setting `PLUGIN_SERVER_ACTION_MATCHING` should now be removed.
