### PR TITLE
Add meta utils, cursor ops

### DIFF
--- a/src/worker/vm/extensions/utilities.ts
+++ b/src/worker/vm/extensions/utilities.ts
@@ -1,0 +1,41 @@
+import { Hub } from '../../../types'
+import { postgresIncrement, postgresSetOnce } from './utils'
+
+interface CursorUtils {
+    init: (key: string, initialValue?: number) => Promise<void>
+    increment: (key: string, incrementBy?: number) => Promise<number>
+}
+
+interface UtilsExtension {
+    cursor: CursorUtils
+}
+
+// These are not utils for internal use!
+// These are general utility functions passed as utils in the plugin meta
+export function createUtils(server: Hub, pluginConfigId: number): UtilsExtension {
+    // Safe cursor utils for multi-threaded applications
+    const cursor: CursorUtils = {
+        init: async function (key, initialValue) {
+            if (!initialValue) {
+                initialValue = 0
+            }
+            if (typeof initialValue !== 'number') {
+                throw new Error(`The cursor's initial value must be a number!`)
+            }
+            await postgresSetOnce(server.db, pluginConfigId, key, initialValue)
+        },
+        increment: async function (key, incrementBy) {
+            if (!incrementBy) {
+                incrementBy = 1
+            }
+            if (typeof incrementBy !== 'number') {
+                throw new Error(`The incrementBy value must be a number!`)
+            }
+            return await postgresIncrement(server.db, pluginConfigId, key, incrementBy)
+        },
+    }
+
+    return {
+        cursor,
+    }
+}

--- a/src/worker/vm/extensions/utils.ts
+++ b/src/worker/vm/extensions/utils.ts
@@ -1,0 +1,42 @@
+import { PluginConfig } from '../../../types'
+import { DB } from '../../../utils/db/db'
+
+// This assumes the value stored at `key` can be cast to a Postgres numeric type
+export const postgresIncrement = async (
+    db: DB,
+    pluginConfigId: PluginConfig['id'],
+    key: string,
+    incrementBy = 1
+): Promise<number> => {
+    const incrementResult = await db.postgresQuery(
+        `
+        INSERT INTO posthog_pluginstorage (plugin_config_id, key, value)
+        VALUES ($1, $2, $3)
+        ON CONFLICT ("plugin_config_id", "key")
+        DO UPDATE SET value = posthog_pluginstorage.value::numeric + ${incrementBy}
+        RETURNING value
+        `,
+        [pluginConfigId, key, incrementBy],
+        'postgresIncrement'
+    )
+
+    return incrementResult.rows[0].value
+}
+
+export const postgresSetOnce = async (
+    db: DB,
+    pluginConfigId: PluginConfig['id'],
+    key: string,
+    value: number
+): Promise<void> => {
+    const se = await db.postgresQuery(
+        `
+        INSERT INTO posthog_pluginstorage (plugin_config_id, key, value)
+        VALUES ($1, $2, $3)
+        ON CONFLICT ("plugin_config_id", "key")
+        DO NOTHING
+         `,
+        [pluginConfigId, key, value],
+        'postgresSetOnce'
+    )
+}

--- a/src/worker/vm/vm.ts
+++ b/src/worker/vm/vm.ts
@@ -11,6 +11,7 @@ import { createJobs } from './extensions/jobs'
 import { createMetrics, setupMetrics } from './extensions/metrics'
 import { createPosthog } from './extensions/posthog'
 import { createStorage } from './extensions/storage'
+import { createUtils } from './extensions/utilities'
 import { imports } from './imports'
 import { transformCode } from './transforms'
 import { upgradeExportEvents } from './upgrades/export-events'
@@ -83,6 +84,7 @@ export async function createPluginConfigVM(
             geoip: createGeoIp(hub),
             jobs: createJobs(hub, pluginConfig),
             metrics: createMetrics(hub, pluginConfig),
+            utils: createUtils(hub, pluginConfig.id),
         },
         '__pluginHostMeta'
     )


### PR DESCRIPTION
## Changes

Tests incoming.

Adds a new object to the plugin meta: `utils`. This way meta doesn't need to grow out of control and we can more neatly let `utils` grow as much as it needs to adding helper functions for plugin devs.

This also adds the first layer of generalized utils stemming from #535: cursors.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
