### PR TITLE
Add delay to CH logs fetching

### DIFF
--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -120,6 +120,8 @@ describe('e2e clickhouse ingestion', () => {
         await delayUntilEventIngested(() => hub.db.fetchEvents())
         await delayUntilEventIngested(() => hub.db.fetchPluginLogEntries())
 
+        await delay(2000)
+
         const pluginLogEntries = await getLogsSinceStart()
         expect(
             pluginLogEntries.filter(({ message, type }) => message.includes('amogus') && type === 'INFO').length


### PR DESCRIPTION
## Changes

CH + Kafka (1) seems to be super flaky around this test, regularly giving a 0 instead of a 1, only for that to be fine 3 retries later. The logic in place should already be enough of a delay but given that that's not working, doesn't hurt to add this and see.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
