### PR TITLE
fix($identify): do not alias same anon id to multiple identified users

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -192,9 +192,8 @@ export class EventsProcessor {
         if (event === '$create_alias') {
             await this.alias(properties['alias'], distinctId, teamId)
         } else if (event === '$identify') {
-            const anonymousDistinctId = properties['$anon_distinct_id']
-            if (anonymousDistinctId) {
-                await this.alias(anonymousDistinctId, distinctId, teamId)
+            if (properties['$anon_distinct_id']) {
+                await this.alias(properties['$anon_distinct_id'], distinctId, teamId)
             }
             await this.setIsIdentified(teamId, distinctId)
         }

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -310,7 +310,10 @@ export class EventsProcessor {
         const newPerson = await this.db.fetchPerson(teamId, distinctId)
 
         if (oldPerson?.is_identified) {
-            console.log('Person associated with previousDistinctId is identified, refusing to alias new distinctId')
+            console.log('Person associated with previousDistinctId is identified, refusing to alias new distinctId', {
+                distinctId,
+                previousDistinctId,
+            })
             return
         }
 

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -192,8 +192,15 @@ export class EventsProcessor {
         if (event === '$create_alias') {
             await this.alias(properties['alias'], distinctId, teamId)
         } else if (event === '$identify') {
-            if (properties['$anon_distinct_id']) {
-                await this.alias(properties['$anon_distinct_id'], distinctId, teamId)
+            // If we are passed an anonymous id that isn't already identified,
+            // then alias it to the passed distinct id and mark it as identified.
+            // Otherwise, we just mark the `distinctId` as identified.
+            const anonymousDistinctId = properties['$anon_distinct_id']
+            if (anonymousDistinctId) {
+                const personForAnonymousId = await this.db.fetchPerson(teamId, anonymousDistinctId)
+                if (!personForAnonymousId?.is_identified) {
+                    await this.alias(anonymousDistinctId, distinctId, teamId)
+                }
             }
             await this.setIsIdentified(teamId, distinctId)
         }


### PR DESCRIPTION
This arises when we have this sequence of events:

```
posthog.capture('event1')
posthog.identify('user1')
posthog.capture('event2')
posthog.identify('user2')
posthog.capture('event3')
```

We want to ensure we associate the anonymous 'event1' with 'user1' when
they are identified, but we do not want to alias 'user1' and 'user2' as
these are separate users. With the previous logic we would associate
both 'user1' and 'user2' with the anonymous id associated with 'event1'
and therefore by transitivity, 'user1' and 'user2' would be associated.

Closes https://github.com/PostHog/posthog/issues/5527