### PR TITLE
Fix attribute-based element filters in action matching

### DIFF
--- a/src/worker/ingestion/action-matcher.ts
+++ b/src/worker/ingestion/action-matcher.ts
@@ -507,7 +507,7 @@ export class ActionMatcher {
                 return false
             }
             for (const [key, value] of Object.entries(requirements.attributes)) {
-                if (attributes[key] !== value) {
+                if (attributes[`attr__${key}`] !== value) {
                     return false
                 }
             }

--- a/tests/worker/ingestion/action-matcher.test.ts
+++ b/tests/worker/ingestion/action-matcher.test.ts
@@ -976,6 +976,26 @@ describe('ActionMatcher', () => {
     })
 
     describe('#checkElementsAgainstSelector()', () => {
+        it('handles selector with attribute', () => {
+            const elements: Element[] = [
+                { tag_name: 'h1', attr_class: ['headline'], attributes: { 'attr__data-attr': 'xyz' } },
+                { tag_name: 'div', attr_class: ['top'] },
+                { tag_name: 'div' },
+                { tag_name: 'main' },
+            ]
+
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "[data-attr='xyz']")).toBeTruthy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "h1[data-attr='xyz']")).toBeTruthy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, ".headline[data-attr='xyz']")).toBeTruthy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "main [data-attr='xyz']")).toBeTruthy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, ".top [data-attr='xyz']")).toBeTruthy()
+
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "[data-attr='foo']")).toBeFalsy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "main[data-attr='xyz']")).toBeFalsy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "div[data-attr='xyz']")).toBeFalsy()
+            expect(actionMatcher.checkElementsAgainstSelector(elements, "div[data-attr='xyz']")).toBeFalsy()
+        })
+
         it('handles any descendant selector', () => {
             const elements: Element[] = [
                 { tag_name: 'h1', attr_class: ['headline'] },


### PR DESCRIPTION
## Changes

Looks like element filtering did not handle attributes properly. Resolves #565.

## Checklist

-   [x] Jest tests
