### PR TITLE
Reorder job queueing for historical exports

### DIFF
--- a/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -120,6 +120,17 @@ export function addHistoricalEventsExportCapability(
             fetchEventsError = error
         }
 
+        const incrementTimestampCursor = events.length === 0
+
+        await meta.jobs
+            .exportEventsFromTheBeginning({
+                timestampCursor,
+                incrementTimestampCursor,
+                retriesPerformedSoFar: 0,
+                intraIntervalOffset: intraIntervalOffset + EVENTS_PER_RUN,
+            })
+            .runNow()
+
         let exportEventsError: Error | unknown | null = null
 
         if (!fetchEventsError) {
@@ -160,18 +171,7 @@ export function addHistoricalEventsExportCapability(
             ).toISOString()}.`
         )
 
-        const incrementTimestampCursor = events.length === 0
-
         incrementMetric('events_exported', events.length)
-
-        await meta.jobs
-            .exportEventsFromTheBeginning({
-                timestampCursor,
-                incrementTimestampCursor,
-                retriesPerformedSoFar: 0,
-                intraIntervalOffset: intraIntervalOffset + EVENTS_PER_RUN,
-            })
-            .runNow()
     }
 
     tasks.job['exportEventsFromTheBeginning'] = {


### PR DESCRIPTION
## Changes

Tiny reordering change that just makes historical exports a tad bit more robust to unexpected server crashes.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
