### PR TITLE
Safer people merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
                   yarn link
 
             - name: Run the linked plugin server from under `posthog/plugins`
-              timeout-minutes: 2
+              timeout-minutes: 5
               env:
                   DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/test_posthog'
                   REDIS_URL: 'redis://localhost'
@@ -118,8 +118,8 @@ jobs:
                   yarn start &> tmp/plugin-server.log &
                   pid=$!
 
-                  echo "⏳ Waiting 10 seconds to see if it runs"
-                  sleep 10
+                  echo "⏳ Waiting 20 seconds to see if it runs"
+                  sleep 20
 
                   echo "🤔 Checking if it's still running, as it should be"
                   if ! kill $pid > /dev/null 2>&1; then
@@ -133,7 +133,7 @@ jobs:
                   echo '🤔 Checking if it logged "All systems go"'
                   str=`cat tmp/plugin-server.log | grep "All systems go"`
                   if [ ! "$str" ];then
-                      sleep 5
+                      sleep 10
                       echo '😵 Did not find "All systems go" in plugin server log output!'
                       echo "🪵 Here's the log:"
                       echo ""
@@ -141,7 +141,7 @@ jobs:
                       exit 1
                   fi
 
-                  sleep 5
+                  sleep 10
                   echo '✅ All systems went!'
                   echo "🪵 Here's the complete log:"
                   echo ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-server",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "description": "PostHog Plugin Server",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/plugin-server",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "description": "PostHog Plugin Server",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -632,14 +632,9 @@ export class DB {
         distinctId: string
     ): Promise<ProducerRecord | void> {
         const insertResult = await client.query(
-            'INSERT INTO posthog_persondistinctid (distinct_id, person_id, team_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING RETURNING *',
+            'INSERT INTO posthog_persondistinctid (distinct_id, person_id, team_id) VALUES ($1, $2, $3) RETURNING *',
             [distinctId, person.id, person.team_id]
         )
-
-        // some other thread already added this ID
-        if (insertResult.rows.length === 0) {
-            return
-        }
 
         const personDistinctIdCreated = insertResult.rows[0] as PersonDistinctId
         if (this.kafkaProducer) {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -374,7 +374,7 @@ export class DB {
     public async fetchPersons(database: Database = Database.Postgres): Promise<Person[] | ClickHousePerson[]> {
         if (database === Database.ClickHouse) {
             const query = `
-            SELECT id, team_id, is_identified, ts as _timestamp, properties, created_at , is_deleted, _offset
+            SELECT id, team_id, is_identified, ts as _timestamp, properties, created_at, is_del as is_deleted, _offset
             FROM (
                 SELECT id,
                     team_id,
@@ -382,7 +382,7 @@ export class DB {
                     max(_timestamp) as ts,
                     argMax(properties, _timestamp) as properties,
                     argMin(created_at, _timestamp) as created_at,
-                    max(is_deleted) as is_deleted,
+                    max(is_deleted) as is_del,
                     argMax(_offset, _timestamp) as _offset
                 FROM person
                 FINAL

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -156,7 +156,7 @@ export class DB {
     public postgresTransaction<ReturnType extends any>(
         transaction: (client: PoolClient) => Promise<ReturnType>
     ): Promise<ReturnType> {
-        return instrumentQuery(this.statsd, 'query.postgres_transaction', undefined, async () => {
+        return instrumentQuery(this.statsd, 'query.postgres_transation', undefined, async () => {
             const timeout = timeoutGuard(`Postgres slow transaction warning after 30 sec!`)
             const client = await this.postgres.connect()
             try {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -374,14 +374,16 @@ export class DB {
     public async fetchPersons(database: Database = Database.Postgres): Promise<Person[] | ClickHousePerson[]> {
         if (database === Database.ClickHouse) {
             const query = `
-            SELECT id, team_id, is_identified, ts as _timestamp, properties, created_at 
+            SELECT id, team_id, is_identified, ts as _timestamp, properties, created_at , is_deleted, _offset
             FROM (
                 SELECT id,
                     team_id,
                     max(is_identified) as is_identified,
                     max(_timestamp) as ts,
                     argMax(properties, _timestamp) as properties,
-                    argMin(created_at, _timestamp) as created_at
+                    argMin(created_at, _timestamp) as created_at,
+                    max(is_deleted) as is_deleted,
+                    argMax(_offset, _timestamp) as _offset
                 FROM person
                 FINAL
                 GROUP BY team_id, id

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -156,7 +156,7 @@ export class DB {
     public postgresTransaction<ReturnType extends any>(
         transaction: (client: PoolClient) => Promise<ReturnType>
     ): Promise<ReturnType> {
-        return instrumentQuery(this.statsd, 'query.postgres_transation', undefined, async () => {
+        return instrumentQuery(this.statsd, 'query.postgres_transaction', undefined, async () => {
             const timeout = timeoutGuard(`Postgres slow transaction warning after 30 sec!`)
             const client = await this.postgres.connect()
             try {

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -529,9 +529,9 @@ export class DB {
                 ],
             }
             if (client) {
-                await this.kafkaProducer.queueMessage(message)
-            } else {
                 kafkaMessages.push(message)
+            } else {
+                await this.kafkaProducer.queueMessage(message)
             }
         }
 

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -313,8 +313,7 @@ export class EventsProcessor {
             try {
                 await this.db.addDistinctId(oldPerson, distinctId)
                 // Catch race case when somebody already added this distinct_id between .get and .addDistinctId
-            } catch (error) {
-                Sentry.captureException(error)
+            } catch {
                 // integrity error
                 if (retryIfFailed) {
                     // run everything again to merge the users if needed
@@ -328,8 +327,7 @@ export class EventsProcessor {
             try {
                 await this.db.addDistinctId(newPerson, previousDistinctId)
                 // Catch race case when somebody already added this distinct_id between .get and .addDistinctId
-            } catch (error) {
-                Sentry.captureException(error)
+            } catch {
                 // integrity error
                 if (retryIfFailed) {
                     // run everything again to merge the users if needed
@@ -345,8 +343,7 @@ export class EventsProcessor {
                     distinctId,
                     previousDistinctId,
                 ])
-            } catch (error) {
-                Sentry.captureException(error)
+            } catch {
                 // Catch race condition where in between getting and creating,
                 // another request already created this person
                 if (retryIfFailed) {

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -450,7 +450,11 @@ export class EventsProcessor {
             try {
                 const updatePersonMessages = await this.db.updatePerson(
                     mergeInto,
-                    { created_at: firstSeen, properties: mergeInto.properties },
+                    {
+                        created_at: firstSeen,
+                        properties: mergeInto.properties,
+                        is_identified: mergeInto.is_identified || otherPerson.is_identified,
+                    },
                     client
                 )
 

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -417,7 +417,7 @@ export class EventsProcessor {
         // between `moveDistinctId` and `deletePerson` being called here
         // – in such a case a distinct ID may be assigned to the person in the database
         // AFTER `otherPersonDistinctIds` was fetched, so this function is not aware of it and doesn't merge it.
-        // That then causeds `deletePerson` to fail, because of foreign key constraints –
+        // That then causes `deletePerson` to fail, because of foreign key constraints –
         // the dangling distinct ID added elsewhere prevents the person from being deleted!
         // This is low-probability so likely won't occur on second retry of this block.
         // In the rare case of the person changing VERY often however, it may happen even a few times,

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -371,7 +371,7 @@ export class EventsProcessor {
                     {},
                     teamId,
                     null,
-                    aliasTriggerEvent === AliasTriggerEvent.Identify,
+                    shouldIdentifyPerson,
                     new UUIDT().toString(),
                     [distinctId, previousDistinctId]
                 )

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -2,6 +2,7 @@ import ClickHouse from '@posthog/clickhouse'
 import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import equal from 'fast-deep-equal'
+import { ProducerRecord } from 'kafkajs'
 import { DateTime, Duration } from 'luxon'
 import { DatabaseError, QueryResult } from 'pg'
 
@@ -389,63 +390,51 @@ export class EventsProcessor {
             firstSeen = otherPerson.created_at
         }
 
-        await this.db.updatePerson(mergeInto, { created_at: firstSeen, properties: mergeInto.properties })
+        let kafkaMessages: ProducerRecord[] = []
 
-        // Merge the distinct IDs
-        await this.db.postgresQuery(
-            'UPDATE posthog_cohortpeople SET person_id = $1 WHERE person_id = $2',
-            [mergeInto.id, otherPerson.id],
-            'updateCohortPeople'
-        )
         let failedAttempts = totalMergeAttempts
-        let shouldRetryAliasOperation = false
 
-        // Retrying merging up to `MAX_FAILED_PERSON_MERGE_ATTEMPTS` times, in case race conditions occur.
-        // An example is a distinct ID being aliased in another plugin server instance,
-        // between `moveDistinctId` and `deletePerson` being called here
-        // – in such a case a distinct ID may be assigned to the person in the database
-        // AFTER `otherPersonDistinctIds` was fetched, so this function is not aware of it and doesn't merge it.
-        // That then causeds `deletePerson` to fail, because of foreign key constraints –
-        // the dangling distinct ID added elsewhere prevents the person from being deleted!
-        // This is low-probability so likely won't occur on second retry of this block.
-        // In the rare case of the person changing VERY often however, it may happen even a few times,
-        // in which case we'll bail and rethrow the error.
-        while (true) {
+        await this.db.postgresTransaction(async (client) => {
             try {
-                await this.db.moveDistinctIds(otherPerson, mergeInto)
+                const updatePersonMessages = await this.db.updatePerson(
+                    mergeInto,
+                    { created_at: firstSeen, properties: mergeInto.properties },
+                    client
+                )
+
+                // Merge the distinct IDs
+                await client.query('UPDATE posthog_cohortpeople SET person_id = $1 WHERE person_id = $2', [
+                    mergeInto.id,
+                    otherPerson.id,
+                ])
+
+                const distinctIdMessages = await this.db.moveDistinctIds(otherPerson, mergeInto)
+
+                const deletePersonMessages = await this.db.deletePerson(otherPerson, client)
+
+                kafkaMessages = [...updatePersonMessages, ...distinctIdMessages, ...deletePersonMessages]
             } catch (error) {
                 Sentry.captureException(error, {
                     extra: { mergeInto, mergeIntoDistinctId, otherPerson, otherPersonDistinctId },
                 })
-                failedAttempts++
 
-                // If a person was deleted in between fetching and moveDistinctId, re-run alias to ensure
-                // the updated persons are fetched and merged safely
-                if (error instanceof RaceConditionError && failedAttempts < MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
-                    shouldRetryAliasOperation = true
-                    break
-                }
-
-                throw error
-            }
-
-            try {
-                await this.db.deletePerson(otherPerson)
-                break // All OK, exiting retry loop
-            } catch (error) {
                 if (!(error instanceof DatabaseError)) {
                     throw error // Very much not OK, this is some completely unexpected error
                 }
+
                 failedAttempts++
                 if (failedAttempts === MAX_FAILED_PERSON_MERGE_ATTEMPTS) {
                     throw error // Very much not OK, failed repeatedly so rethrowing the error
                 }
-                continue // Not OK, trying again to make sure that ALL distinct IDs are merged
-            }
-        }
 
-        if (shouldRetryAliasOperation) {
-            await this.alias(otherPersonDistinctId, mergeIntoDistinctId, teamId, false, failedAttempts)
+                await this.alias(otherPersonDistinctId, mergeIntoDistinctId, teamId, false, failedAttempts)
+            }
+        })
+
+        if (this.kafkaProducer) {
+            for (const kafkaMessage of kafkaMessages) {
+                await this.kafkaProducer.queueMessage(kafkaMessage)
+            }
         }
     }
 

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon'
+import { PoolClient } from 'pg'
 
 import { startPluginsServer } from '../../src/main/pluginsServer'
 import { Database, Hub, LogLevel, PluginsServerConfig, Team, TimestampFormat } from '../../src/types'
@@ -273,7 +274,9 @@ describe('postgres parity', () => {
 
         // delete person
 
-        await hub.db.deletePerson(person)
+        await hub.db.postgresTransaction(async (client) => {
+            await hub.db.deletePerson(person, client)
+        })
 
         // Check distinct ids
         await delayUntilEventIngested(async () =>

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -111,8 +111,7 @@ describe('postgres parity', () => {
         await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse))
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(person, Database.ClickHouse), 2)
 
-        // update JSON and boolean to true
-
+        // update properties and set is_identified to true
         await hub.db.updatePerson(person, { properties: { replacedUserProp: 'propValue' }, is_identified: true })
 
         await delayUntilEventIngested(async () =>
@@ -229,9 +228,15 @@ describe('postgres parity', () => {
     test('moveDistinctIds & deletePerson', async () => {
         const uuid = new UUIDT().toString()
         const uuid2 = new UUIDT().toString()
-        const person = await hub.db.createPerson(DateTime.utc(), { userProp: 'propValue' }, team.id, null, true, uuid, [
-            'distinct1',
-        ])
+        const person = await hub.db.createPerson(
+            DateTime.utc(),
+            { userProp: 'propValue' },
+            team.id,
+            null,
+            false,
+            uuid,
+            ['distinct1']
+        )
         const anotherPerson = await hub.db.createPerson(
             DateTime.utc(),
             { userProp: 'propValue' },
@@ -245,8 +250,6 @@ describe('postgres parity', () => {
         const [postgresPerson] = await hub.db.fetchPersons(Database.Postgres)
 
         await delayUntilEventIngested(() => hub.db.fetchDistinctIdValues(postgresPerson, Database.ClickHouse), 1)
-        const clickHouseDistinctIdValues = await hub.db.fetchDistinctIdValues(postgresPerson, Database.ClickHouse)
-        const postgresDistinctIdValues = await hub.db.fetchDistinctIdValues(postgresPerson, Database.Postgres)
 
         // move distinct ids from person to to anotherPerson
 

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -4,7 +4,7 @@ import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../src/config/kafka-topics'
 import { Event, PluginsServerConfig } from '../../src/types'
 import { resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetKafka } from '../helpers/kafka'
-import { getFirstTeam } from '../helpers/sql'
+import { getFirstTeam, resetTestDatabase } from '../helpers/sql'
 import { createPerson, createProcessEventTests } from '../shared/process-event'
 
 jest.setTimeout(180_000) // 3 minute timeout
@@ -68,6 +68,8 @@ describe('process event (clickhouse)', () => {
 
             // moveDistinctIds 2x, deletePerson 1x
             expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(3)
+
+            await resetTestDatabase()
         })
     })
 })

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -1,8 +1,11 @@
+import { DateTime } from 'luxon'
+
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../src/config/kafka-topics'
 import { Event, PluginsServerConfig } from '../../src/types'
 import { resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetKafka } from '../helpers/kafka'
-import { createProcessEventTests } from '../shared/process-event'
+import { getFirstTeam } from '../helpers/sql'
+import { createPerson, createProcessEventTests } from '../shared/process-event'
 
 jest.setTimeout(180_000) // 3 minute timeout
 
@@ -21,5 +24,48 @@ describe('process event (clickhouse)', () => {
         await resetTestDatabaseClickhouse(extraServerConfig)
     })
 
-    createProcessEventTests('clickhouse', extraServerConfig)
+    createProcessEventTests('clickhouse', extraServerConfig, (response) => {
+        test('mergePeople kafka messages are only enqueued after all postgres steps succeed', async () => {
+            const { hub } = response
+
+            const team = await getFirstTeam(hub!)
+            const p0 = await createPerson(hub!, team, ['person_0'], { $os: 'Microsoft' })
+
+            await hub!.db.updatePerson(p0, { created_at: DateTime.fromISO('2020-01-01T00:00:00Z') })
+
+            const p1 = await createPerson(hub!, team, ['person_1'], { $os: 'Chrome', $browser: 'Chrome' })
+
+            await hub!.db.updatePerson(p1, { created_at: DateTime.fromISO('2019-07-01T00:00:00Z') })
+
+            expect((await hub!.db.fetchPersons()).length).toEqual(2)
+            const [person0, person1] = await hub!.db.fetchPersons()
+
+            hub!.db.updatePerson = jest.fn(() => {
+                throw new Error()
+            })
+
+            await hub!.eventsProcessor!.mergePeople({
+                mergeInto: person0,
+                mergeIntoDistinctId: 'person_0',
+                otherPerson: person1,
+                otherPersonDistinctId: 'person_1',
+                totalMergeAttempts: 0,
+            })
+
+            expect(hub!.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
+
+            hub!.db.updatePerson = jest.fn()
+
+            await hub!.eventsProcessor!.mergePeople({
+                mergeInto: person0,
+                mergeIntoDistinctId: 'person_0',
+                otherPerson: person1,
+                otherPersonDistinctId: 'person_1',
+                totalMergeAttempts: 0,
+            })
+
+            // updatePerson 1x, moveDistinctIds 2x, deletePerson 1x
+            expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(4)
+        })
+    })
 })

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -24,52 +24,5 @@ describe('process event (clickhouse)', () => {
         await resetTestDatabaseClickhouse(extraServerConfig)
     })
 
-    createProcessEventTests('clickhouse', extraServerConfig, (response) => {
-        test('mergePeople kafka messages are only enqueued after all postgres steps succeed', async () => {
-            const { hub } = response
-
-            const team = await getFirstTeam(hub!)
-            const p0 = await createPerson(hub!, team, ['person_0'], { $os: 'Microsoft' })
-
-            await hub!.db.updatePerson(p0, { created_at: DateTime.fromISO('2020-01-01T00:00:00Z') })
-
-            const p1 = await createPerson(hub!, team, ['person_1'], { $os: 'Chrome', $browser: 'Chrome' })
-
-            await hub!.db.updatePerson(p1, { created_at: DateTime.fromISO('2019-07-01T00:00:00Z') })
-
-            expect((await hub!.db.fetchPersons()).length).toEqual(2)
-            const [person0, person1] = await hub!.db.fetchPersons()
-
-            jest.spyOn(hub!.db, 'updatePerson').mockImplementationOnce(() => {
-                throw new Error('updatePerson error')
-            })
-
-            hub!.db.kafkaProducer!.queueMessage = jest.fn()
-
-            await expect(async () => {
-                await hub!.eventsProcessor!.mergePeople({
-                    mergeInto: person0,
-                    mergeIntoDistinctId: 'person_0',
-                    otherPerson: person1,
-                    otherPersonDistinctId: 'person_1',
-                    totalMergeAttempts: 0,
-                })
-            }).rejects.toThrow()
-
-            expect(hub!.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
-
-            await hub!.eventsProcessor!.mergePeople({
-                mergeInto: person0,
-                mergeIntoDistinctId: 'person_0',
-                otherPerson: person1,
-                otherPersonDistinctId: 'person_1',
-                totalMergeAttempts: 0,
-            })
-
-            // moveDistinctIds 2x, deletePerson 1x
-            expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(3)
-
-            await resetTestDatabase()
-        })
-    })
+    createProcessEventTests('clickhouse', extraServerConfig)
 })

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -24,7 +24,9 @@ describe('process event (clickhouse)', () => {
         await resetTestDatabaseClickhouse(extraServerConfig)
     })
 
-    createProcessEventTests('clickhouse', extraServerConfig, (response) => {
+    createProcessEventTests(
+        'clickhouse',
+        extraServerConfig /* , (response) => {
         test('mergePeople kafka messages are only enqueued after all postgres steps succeed', async () => {
             const { hub } = response
 
@@ -65,5 +67,6 @@ describe('process event (clickhouse)', () => {
             // updatePerson 1x, moveDistinctIds 2x, deletePerson 1x
             expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(4)
         })
-    })
+    } */
+    )
 })

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -44,6 +44,8 @@ describe('process event (clickhouse)', () => {
                 throw new Error('updatePerson error')
             })
 
+            hub!.db.kafkaProducer!.queueMessage = jest.fn()
+
             await expect(async () => {
                 await hub!.eventsProcessor!.mergePeople({
                     mergeInto: person0,
@@ -56,18 +58,16 @@ describe('process event (clickhouse)', () => {
 
             expect(hub!.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
 
-            await expect(async () => {
-                await hub!.eventsProcessor!.mergePeople({
-                    mergeInto: person0,
-                    mergeIntoDistinctId: 'person_0',
-                    otherPerson: person1,
-                    otherPersonDistinctId: 'person_1',
-                    totalMergeAttempts: 0,
-                })
-            }).rejects.not.toThrow()
+            await hub!.eventsProcessor!.mergePeople({
+                mergeInto: person0,
+                mergeIntoDistinctId: 'person_0',
+                otherPerson: person1,
+                otherPersonDistinctId: 'person_1',
+                totalMergeAttempts: 0,
+            })
 
-            // updatePerson 1x, moveDistinctIds 2x, deletePerson 1x
-            expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(4)
+            // moveDistinctIds 2x, deletePerson 1x
+            expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(3)
         })
     })
 })

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -24,9 +24,7 @@ describe('process event (clickhouse)', () => {
         await resetTestDatabaseClickhouse(extraServerConfig)
     })
 
-    createProcessEventTests(
-        'clickhouse',
-        extraServerConfig /* , (response) => {
+    createProcessEventTests('clickhouse', extraServerConfig, (response) => {
         test('mergePeople kafka messages are only enqueued after all postgres steps succeed', async () => {
             const { hub } = response
 
@@ -67,6 +65,5 @@ describe('process event (clickhouse)', () => {
             // updatePerson 1x, moveDistinctIds 2x, deletePerson 1x
             expect(hub!.db.kafkaProducer!.queueMessage).toHaveBeenCalledTimes(4)
         })
-    } */
-    )
+    })
 })

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -40,7 +40,7 @@ describe('process event (clickhouse)', () => {
             expect((await hub!.db.fetchPersons()).length).toEqual(2)
             const [person0, person1] = await hub!.db.fetchPersons()
 
-            hub!.db.updatePerson = jest.fn(() => {
+            jest.spyOn(hub!.db, 'updatePerson').mockImplementationOnce(() => {
                 throw new Error()
             })
 
@@ -53,8 +53,6 @@ describe('process event (clickhouse)', () => {
             })
 
             expect(hub!.db.kafkaProducer!.queueMessage).not.toHaveBeenCalled()
-
-            hub!.db.updatePerson = jest.fn()
 
             await hub!.eventsProcessor!.mergePeople({
                 mergeInto: person0,

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -234,13 +234,13 @@ export const createProcessEventTests = (
             new UUIDT().toString()
         )
 
+        expect((await hub.db.fetchPersons()).length).toEqual(2)
+        const [person0, person1] = await hub.db.fetchPersons()
+
         if (database === 'clickhouse') {
             await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
             expect((await hub.db.fetchPersons(Database.ClickHouse)).length).toEqual(2)
         }
-
-        expect((await hub.db.fetchPersons()).length).toEqual(2)
-        const [person0, person1] = await hub.db.fetchPersons()
 
         await eventsProcessor.mergePeople({
             mergeInto: person0,

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -240,6 +240,7 @@ export const createProcessEventTests = (
         if (database === 'clickhouse') {
             await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
             const chPeople = await hub.db.fetchPersons(Database.ClickHouse)
+            console.log(chPeople)
             expect(chPeople.length).toEqual(2)
         }
 

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -308,10 +308,11 @@ export const createProcessEventTests = (
             new UUIDT().toString()
         )
 
+        // TODO: Make this test actually useful and not flaky
         if (database === 'clickhouse') {
             expect(queryCounter).toBe(10 + 14 /* event & prop definitions */)
         } else if (database === 'postgresql') {
-            expect(queryCounter).toBe(13 + 14 /* event & prop definitions */)
+            expect(queryCounter).toBe(14 + 14 /* event & prop definitions */)
         }
 
         let persons = await hub.db.fetchPersons()

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -311,7 +311,7 @@ export const createProcessEventTests = (
 
         // TODO: Make this test actually useful and not flaky
         if (database === 'clickhouse') {
-            expect(queryCounter).toBe(10 + 14 /* event & prop definitions */)
+            expect(queryCounter).toBe(11 + 14 /* event & prop definitions */)
         } else if (database === 'postgresql') {
             expect(queryCounter).toBe(14 + 14 /* event & prop definitions */)
         }

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -331,7 +331,7 @@ export const createProcessEventTests = (
         expect(events[0].properties).toEqual({
             $ip: '127.0.0.1',
             $os: 'Mac OS X',
-            $set: { utm_medium: 'twitter' },
+            $set: { utm_medium: 'twitter', $gclid: 'GOOGLE ADS ID' },
             token: 'THIS IS NOT A TOKEN FOR TEAM 2',
             $browser: 'Chrome',
             $set_once: {
@@ -340,11 +340,13 @@ export const createProcessEventTests = (
                 $initial_utm_medium: 'twitter',
                 $initial_current_url: 'https://test.com',
                 $initial_browser_version: false,
+                $initial_gclid: 'GOOGLE ADS ID',
             },
             utm_medium: 'twitter',
             distinct_id: 2,
             $current_url: 'https://test.com',
             $browser_version: false,
+            $gclid: 'GOOGLE ADS ID',
             $initial_referrer_url: 'https://google.com/?q=posthog',
             $initial_referring_domain: 'https://google.com',
         })

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -331,7 +331,7 @@ export const createProcessEventTests = (
         expect(events[0].properties).toEqual({
             $ip: '127.0.0.1',
             $os: 'Mac OS X',
-            $set: { utm_medium: 'twitter', $gclid: 'GOOGLE ADS ID' },
+            $set: { utm_medium: 'twitter', gclid: 'GOOGLE ADS ID' },
             token: 'THIS IS NOT A TOKEN FOR TEAM 2',
             $browser: 'Chrome',
             $set_once: {
@@ -346,7 +346,7 @@ export const createProcessEventTests = (
             distinct_id: 2,
             $current_url: 'https://test.com',
             $browser_version: false,
-            $gclid: 'GOOGLE ADS ID',
+            gclid: 'GOOGLE ADS ID',
             $initial_referrer_url: 'https://google.com/?q=posthog',
             $initial_referring_domain: 'https://google.com',
         })

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -389,6 +389,8 @@ export const createProcessEventTests = (
             $initial_current_url: 'https://test.com',
             $initial_os: 'Mac OS X',
             utm_medium: 'instagram',
+            $initial_gclid: 'GOOGLE ADS ID',
+            gclid: 'GOOGLE ADS ID',
         })
         expect(events[1].properties.$set).toEqual({
             utm_medium: 'instagram',
@@ -526,6 +528,14 @@ export const createProcessEventTests = (
                 id: expect.any(String),
                 is_numerical: false,
                 name: 'utm_medium',
+                query_usage_30_day: null,
+                team_id: 2,
+                volume_30_day: null,
+            },
+            {
+                id: expect.any(String),
+                is_numerical: false,
+                name: 'gclid',
                 query_usage_30_day: null,
                 team_id: 2,
                 volume_30_day: null,

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -239,7 +239,8 @@ export const createProcessEventTests = (
 
         if (database === 'clickhouse') {
             await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
-            expect((await hub.db.fetchPersons(Database.ClickHouse)).length).toEqual(2)
+            const chPeople = await hub.db.fetchPersons(Database.ClickHouse)
+            expect(chPeople.length).toEqual(2)
         }
 
         await eventsProcessor.mergePeople({

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -240,7 +240,6 @@ export const createProcessEventTests = (
         if (database === 'clickhouse') {
             await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
             const chPeople = await hub.db.fetchPersons(Database.ClickHouse)
-            console.log(chPeople)
             expect(chPeople.length).toEqual(2)
         }
 

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -1502,6 +1502,8 @@ export const createProcessEventTests = (
             // initialDistictId
             await identify(hub, initialDistinctId)
 
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 7)
+
             // Get pairins of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)
 
@@ -1546,6 +1548,8 @@ export const createProcessEventTests = (
             // Let's also make sure that we do not alias when switching back to
             // initialDistictId
             await identify(hub, initialDistinctId)
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 6)
 
             // Get pairins of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)
@@ -1613,6 +1617,8 @@ export const createProcessEventTests = (
             // set the first identify going
             await identify(hub, initialDistinctId)
 
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 3)
+
             // Let's first just make sure `updatePerson` was called, as a way of
             // checking that our mocking was actually invoked
             expect(hub.db.createPerson).toHaveBeenCalled()
@@ -1640,6 +1646,8 @@ export const createProcessEventTests = (
             await identify(hub, identifiedId2)
 
             await alias(hub, identifiedId1, identifiedId2)
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 4)
 
             // Get pairings of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)
@@ -1669,6 +1677,8 @@ export const createProcessEventTests = (
             // Then try to alias them
             await alias(hub, anonymousId, initialDistinctId)
 
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 3)
+
             // Get pairings of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)
 
@@ -1696,6 +1706,8 @@ export const createProcessEventTests = (
 
             // Then try to alias them
             await alias(hub, initialDistinctId, anonymousId)
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 3)
 
             // Get pairings of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)
@@ -1726,6 +1738,8 @@ export const createProcessEventTests = (
             // Then try to alias them
             await alias(hub, anonymous1, anonymous2)
 
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 3)
+
             // Get pairings of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)
 
@@ -1749,6 +1763,8 @@ export const createProcessEventTests = (
             // Then try to alias them
             state.currentDistinctId = anonymous1
             await alias(hub, anonymous2, anonymous1)
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 1)
 
             // Get pairings of person distinctIds and the events associated with them
             const eventsByPerson = await getEventsByPerson(hub)

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -64,6 +64,7 @@ export const getEventsByPerson = async (hub: Hub) => {
                 distinctIds,
                 (events as Event[])
                     .filter((event) => distinctIds.includes(event.distinct_id))
+                    .sort((e1, e2) => new Date(e1.timestamp).getTime() - new Date(e2.timestamp).getTime())
                     .map((event) => event.event),
             ] as const
         })
@@ -174,8 +175,8 @@ export const createProcessEventTests = (
             event: eventName,
             distinct_id: properties.distinct_id ?? state.currentDistinctId,
             properties: properties,
-            now: '2021-09-08T15:51:51.072Z',
-            sent_at: '2021-09-08T15:51:51.072Z',
+            now: new Date().toISOString(),
+            sent_at: new Date().toISOString(),
             ip: '127.0.0.1',
             site_url: 'https://posthog.com',
             team_id: team.id,

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -237,14 +237,14 @@ export const createProcessEventTests = (
         expect((await hub.db.fetchPersons()).length).toEqual(2)
         const [person0, person1] = await hub.db.fetchPersons()
 
-        jest.spyOn(hub!.db.kafkaProducer!, 'queueMessage')
-
         if (database === 'clickhouse') {
             await delayUntilEventIngested(() => hub.db.fetchPersons(Database.ClickHouse), 2)
             const chPeople = await hub.db.fetchPersons(Database.ClickHouse)
             expect(chPeople.length).toEqual(2)
 
             // try to merge and see if we queue any messages
+            jest.spyOn(hub!.db.kafkaProducer!, 'queueMessage')
+
             jest.spyOn(hub!.db, 'updatePerson').mockImplementationOnce(() => {
                 throw new Error('updatePerson error')
             })

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -39,7 +39,7 @@ export async function delayUntilEventIngested(
     }
 }
 
-async function createPerson(
+export async function createPerson(
     server: Hub,
     team: Team,
     distinctIds: string[],
@@ -48,9 +48,9 @@ async function createPerson(
     return server.db.createPerson(DateTime.utc(), properties, team.id, null, false, new UUIDT().toString(), distinctIds)
 }
 
-type ReturnWithHub = { hub?: Hub; closeHub?: () => Promise<void> }
+export type ReturnWithHub = { hub?: Hub; closeHub?: () => Promise<void> }
 
-const getEventsByPerson = async (hub: Hub) => {
+export const getEventsByPerson = async (hub: Hub) => {
     // Helper function to retrieve events paired with their associated distinct
     // ids
     const persons = await hub.db.fetchPersons()
@@ -70,7 +70,7 @@ const getEventsByPerson = async (hub: Hub) => {
     )
 }
 
-const createIdentifiedPerson = async (hub: Hub, teamId: number, distinctId: string): Promise<void> => {
+export const createIdentifiedPerson = async (hub: Hub, teamId: number, distinctId: string): Promise<void> => {
     await hub.db.createPerson(DateTime.utc(), {}, teamId, null, true, new UUIDT().toString(), [distinctId])
 }
 
@@ -1565,7 +1565,6 @@ export const createProcessEventTests = (
             // checking that our mocking was actually invoked
             expect(hub.db.createPerson).toHaveBeenCalled()
 
-            await delay(5000)
             // Now make sure that we have one person in the db that has been
             // identified
             const persons = await hub.db.fetchPersons()


### PR DESCRIPTION
## Changes

~~**A LOT** more info coming soon, hold tight~~

Still some things to fix here.

Also thanks a lot to @hazzadous for the initial work here and a very solid foundation for the bulk of the tests here. The tests you wrote were very good.

So this PR batches 2 changes in 1. This is unfortunate but was a decision made to ship faster, given they both made significant changes to the same area of the codebase, looking to fix the same issue, just taking different approaches.

The 2 changes are:

1. A refactor of `mergePeople`. Doing away with the sketchy `while (true)` loop and logic that was very prone to leaving things out of sync. The big problem here is that we were enqueueing kafka messages for updates to CH directly at each update to Postgres, which is _bad_. Really we want to only enqueue all the messages when we know everything we should do in Postgres has succeeded, which we can accomplish with a transaction.
2. Fixing https://github.com/PostHog/posthog/issues/5527 by not allowing a merge from an identified user.

1 is reasonably self-explanatory. 2 needs some context and I had to think quite a bit about how to conceptually approach it.

### $create_alias

This has been left alone. If someone explicitly asks us to merge 2 users, we _will_ do it. It's much harder to shoot yourself in the foot here, and we shouldn't infer for users that they don't want to merge 2 users they explicitly chose to merge. Plus `$create_alias` underpins our person merge modal, where users can manually pick in a very explicit way what users they want to merge into one. We should let them do that, identified or not.

### $identify

Here's where things get tricky. Here's a table explaining all the paths and their results:

> Note: Distinct ID 1 refers to the person we're merging **from**, and Distinct ID 2 is the person we're merging **into**

| Distinct ID 1 exists | Person for Distinct ID 1 is identified | Distinct ID 2 exists | Person for Distinct ID 2 is identified  | Outcome |
| :-------------: | :-------------: | :-------------: | :-------------: | :-------------: |
| 🚫 | 🚫 | 🚫 | 🚫 | Create person with both distinct IDs |
| 🚫 | 🚫 | ✅  | 🚫 | Add Distinct ID 1 to the person for Distinct ID 2 |
| 🚫 | 🚫 | ✅  | ✅  | Add Distinct ID 1 to the person for Distinct ID 2 |
| ✅ | 🚫 | 🚫 | 🚫 | Add Distinct ID 2 to the person for Distinct ID 1 |
| ✅ | ✅ | 🚫 | 🚫 | Add Distinct ID 2 to the person for Distinct ID 1 |
| ✅ | 🚫 | ✅  | 🚫 | Merge the two people |
| ✅ | 🚫 | ✅  | ✅ | Merge the person for distinct ID 1 (anonymous) into the one for distinct ID 2 (identified) |
| ✅ | ✅ | ✅  | ✅ | Do not merge!! Leave the 2 people alone. |
| ✅ | ✅ | ✅  | 🚫 |  Do not merge!! We will not merge an identified person into an anonymous one |



## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
