### PR TITLE
chore(test): reduce the test timeouts to make tests fail faster

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
     coverageProvider: 'v8',
     setupFilesAfterEnv: ['./jest.setup.fetch-mock.js'],
     testMatch: ['<rootDir>/tests/**/*.test.ts', '<rootDir>/benchmarks/**/*.benchmark.ts'],
+    testTimeout: 5_000,
 }

--- a/tests/clickhouse/e2e.test.ts
+++ b/tests/clickhouse/e2e.test.ts
@@ -15,7 +15,6 @@ import { delayUntilEventIngested } from '../shared/process-event'
 const { console: testConsole } = writeToFile
 
 jest.mock('../../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,

--- a/tests/clickhouse/postgres-parity.test.ts
+++ b/tests/clickhouse/postgres-parity.test.ts
@@ -12,7 +12,6 @@ import { getFirstTeam, resetTestDatabase } from '../helpers/sql'
 import { delayUntilEventIngested } from '../shared/process-event'
 
 jest.mock('../../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,

--- a/tests/clickhouse/process-event.test.ts
+++ b/tests/clickhouse/process-event.test.ts
@@ -4,7 +4,7 @@ import { resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { resetKafka } from '../helpers/kafka'
 import { createProcessEventTests } from '../shared/process-event'
 
-jest.setTimeout(180_000) // 3 minute timeout
+jest.setTimeout(10_000) // 10 seconds
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
     KAFKA_ENABLED: true,

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -6,8 +6,6 @@ import { pluginConfig39 } from './helpers/plugins'
 import { getErrorForPluginConfig, resetTestDatabase } from './helpers/sql'
 import { delayUntilEventIngested } from './shared/process-event'
 
-jest.setTimeout(60000) // 60 sec timeout
-
 const extraServerConfig: Partial<PluginsServerConfig> = {
     WORKER_CONCURRENCY: 2,
     PLUGINS_CELERY_QUEUE: 'test-plugins-celery-queue-errors',

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -33,6 +33,7 @@ jest.mock('../src/utils/db/s3-wrapper', () => {
 })
 jest.mock('../src/utils/db/sql')
 jest.mock('../src/utils/kill')
+jest.setTimeout(20_000) // 20 sec timeout
 
 const { console: testConsole } = writeToFile
 

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -33,7 +33,6 @@ jest.mock('../src/utils/db/s3-wrapper', () => {
 })
 jest.mock('../src/utils/db/sql')
 jest.mock('../src/utils/kill')
-jest.setTimeout(60000) // 60 sec timeout
 
 const { console: testConsole } = writeToFile
 

--- a/tests/mmdb.test.ts
+++ b/tests/mmdb.test.ts
@@ -29,7 +29,7 @@ async function resetTestDatabaseWithMmdb(): Promise<void> {
 
 let serverInstance: ServerInstance
 
-jest.setTimeout(30_000)
+jest.setTimeout(30_000) // 30 seconds
 
 afterEach(async () => {
     await serverInstance?.stop()

--- a/tests/postgres/e2e.test.ts
+++ b/tests/postgres/e2e.test.ts
@@ -14,7 +14,6 @@ import { delayUntilEventIngested } from '../shared/process-event'
 const { console: testConsole } = writeToFile
 
 jest.mock('../../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
 
 // TODO: merge these tests with clickhouse/e2e.test.ts
 describe('e2e postgres ingestion', () => {

--- a/tests/postgres/e2e.timeout.test.ts
+++ b/tests/postgres/e2e.timeout.test.ts
@@ -7,8 +7,6 @@ import { pluginConfig39 } from '../helpers/plugins'
 import { resetTestDatabase } from '../helpers/sql'
 import { delayUntilEventIngested } from '../shared/process-event'
 
-jest.setTimeout(60000) // 60 sec timeout
-
 describe('e2e postgres ingestion timeout', () => {
     let hub: Hub
     let stopServer: () => Promise<void>

--- a/tests/postgres/process-event.test.ts
+++ b/tests/postgres/process-event.test.ts
@@ -1,7 +1,7 @@
 import { createUserTeamAndOrganization, getTeams } from '../helpers/sql'
 import { createProcessEventTests } from '../shared/process-event'
 
-jest.setTimeout(600000) // 600 sec timeout.
+jest.setTimeout(5_000) // 5 seconds
 
 describe('process event (postgresql)', () => {
     createProcessEventTests('postgresql', {}, (response) => {

--- a/tests/postgres/queue.test.ts
+++ b/tests/postgres/queue.test.ts
@@ -6,8 +6,6 @@ import { createHub } from '../../src/utils/db/hub'
 import { delay } from '../../src/utils/utils'
 import { runProcessEvent } from '../../src/worker/plugins/run'
 
-jest.setTimeout(60000) // 60 sec timeout
-
 function advanceOneTick() {
     return new Promise((resolve) => process.nextTick(resolve))
 }

--- a/tests/postgres/teardown.test.ts
+++ b/tests/postgres/teardown.test.ts
@@ -6,7 +6,6 @@ import { pluginConfig39 } from '../helpers/plugins'
 import { getErrorForPluginConfig, resetTestDatabase } from '../helpers/sql'
 
 jest.mock('../../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
 
 const defaultEvent = {
     distinct_id: 'my_id',

--- a/tests/postgres/vm.test.ts
+++ b/tests/postgres/vm.test.ts
@@ -13,7 +13,7 @@ import { plugin60 } from './../helpers/plugins'
 
 jest.mock('../../src/utils/celery/client')
 jest.mock('../../src/main/job-queues/job-queue-manager')
-jest.setTimeout(30000)
+jest.setTimeout(10_000) // 10 seconds
 
 const defaultEvent = {
     distinct_id: 'my_id',

--- a/tests/postgres/worker.test.ts
+++ b/tests/postgres/worker.test.ts
@@ -28,7 +28,7 @@ jest.mock('../../src/worker/ingestion/ingest-event')
 jest.mock('../../src/worker/plugins/run')
 jest.mock('../../src/worker/plugins/setup')
 jest.mock('../../src/worker/plugins/teardown')
-jest.setTimeout(600000) // 600 sec timeout
+jest.setTimeout(60_000) // 60 sec timeout
 
 function createEvent(index = 0): PluginEvent {
     return {

--- a/tests/schedule.test.ts
+++ b/tests/schedule.test.ts
@@ -18,7 +18,6 @@ import { setupPiscina } from './helpers/worker'
 
 jest.mock('../src/utils/db/sql')
 jest.mock('../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
 
 function createEvent(index = 0): PluginEvent {
     return {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -10,7 +10,6 @@ import { resetTestDatabase } from './helpers/sql'
 jest.mock('@sentry/node')
 jest.mock('../src/utils/db/sql')
 jest.mock('../src/utils/kill')
-jest.setTimeout(60000) // 60 sec timeout
 
 test('startPluginsServer', async () => {
     const testCode = `

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -12,7 +12,7 @@ import { EventProcessingResult, EventsProcessor } from '../../src/worker/ingesti
 import { createUserTeamAndOrganization, getFirstTeam, getTeams, onQuery, resetTestDatabase } from '../helpers/sql'
 
 jest.mock('../../src/utils/status')
-jest.setTimeout(600000) // 600 sec timeout.
+jest.setTimeout(60_000) // 60 sec timeout.
 
 export async function delayUntilEventIngested(
     fetchEvents: () => Promise<any[] | any>,

--- a/tests/transforms.test.ts
+++ b/tests/transforms.test.ts
@@ -7,6 +7,8 @@ import { resetTestDatabase } from './helpers/sql'
 let hub: Hub
 let closeHub: () => Promise<void>
 
+jest.setTimeout(20_000) // 20 second timeout
+
 beforeEach(async () => {
     ;[hub, closeHub] = await createHub()
     await resetTestDatabase(`const processEvent = event => event`)


### PR DESCRIPTION
There are some really large timeouts in here, which makes tests appear
to hang. It's not a wonderful dev experience. It looks to me like these
tests should be running much faster than the specified timeouts.