### PR TITLE
Split identification flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "main": "dist/index.js",
     "scripts": {
         "test": "jest --runInBand --forceExit tests/**/*.test.ts",
-        "test:postgres:1": "jest --runInBand --forceExit tests/*.test.ts",
+        "test:postgres:1": "jest --runInBand --forceExit tests/*.test.ts tests/shared/db.test.ts",
         "test:postgres:2": "jest --runInBand --forceExit tests/postgres/*.test.ts",
-        "test:clickhouse:1": "jest --runInBand --forceExit tests/clickhouse/postgres-parity.test.ts tests/clickhouse/e2e.test.ts tests/clickhouse/ingestion-utils.test.ts",
+        "test:clickhouse:1": "jest --runInBand --forceExit tests/clickhouse/postgres-parity.test.ts tests/clickhouse/e2e.test.ts tests/clickhouse/ingestion-utils.test.ts tests/shared/db.test.ts",
         "test:clickhouse:2": "jest --runInBand --forceExit tests/clickhouse/process-event.test.ts",
         "benchmark": "yarn run benchmarks:clickhouse && yarn run benchmark:postgres && yarn run benchmarks:vm",
         "benchmark:clickhouse": "node --expose-gc node_modules/.bin/jest --runInBand benchmarks/clickhouse/",

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -281,7 +281,7 @@ export class EventsProcessor {
         return returnedProps
     }
 
-    private async setIsIdentified(teamId: number, distinctId: string, isIdentified = true): Promise<void> {
+    private async setIsIdentified(teamId: number, distinctId: string): Promise<void> {
         let personFound = await this.db.fetchPerson(teamId, distinctId)
         if (!personFound) {
             try {
@@ -301,7 +301,7 @@ export class EventsProcessor {
             }
         }
         if (personFound && !personFound.is_identified) {
-            await this.db.updatePerson(personFound, { is_identified: isIdentified })
+            await this.db.setPersonAsIdentified(personFound)
         }
     }
 


### PR DESCRIPTION
## Changes

Splits identifying a person away from `updatePerson` and makes it more robust. Now we don't update Kafka if we don't need to and conceptually it makes sense to have this separate.

This will also make even more sense once I completely re-do `updatePerson`, as I want to have that focus solely on properties.




## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
