### PR TITLE
Bring `URL` into plugin VMs

### DIFF
--- a/src/worker/vm/vm.ts
+++ b/src/worker/vm/vm.ts
@@ -56,6 +56,9 @@ export async function createPluginConfigVM(
 
     vm.freeze(RetryError, 'RetryError')
 
+    // Bring some useful globals into scope
+    vm.freeze(URL, 'URL')
+
     // Creating this outside the vm (so not in a babel plugin for example)
     // because `setTimeout` is not available inside the vm... and we don't want to
     // make it available for now, as it makes it easier to create malicious code


### PR DESCRIPTION
## Changes

A user wanted to handle some URLs in a plugin (query params etc.), but our VMs don't offer `URL`. Seems sensible to just bring it into scope.