### PR TITLE
Adjust selector matching for property values being in an array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -569,7 +569,7 @@ export interface PersonPropertyFilter extends PropertyFilterWithOperator {
 export interface ElementPropertyFilter extends PropertyFilterWithOperator {
     type: 'element'
     key: 'tag_name' | 'text' | 'href' | 'selector'
-    value: string
+    value: string | string[]
 }
 
 /** Sync with posthog/frontend/src/types.ts */

--- a/src/worker/ingestion/action-matcher.ts
+++ b/src/worker/ingestion/action-matcher.ts
@@ -335,7 +335,10 @@ export class ActionMatcher {
      */
     private checkEventAgainstElementFilter(elements: Element[], filter: ElementPropertyFilter): boolean {
         if (filter.key === 'selector') {
-            return filter.value ? this.checkElementsAgainstSelector(elements, filter.value) : false
+            const okValues = Array.isArray(filter.value) ? filter.value : [filter.value]
+            return okValues.some((okValue) =>
+                okValue ? this.checkElementsAgainstSelector(elements, okValue.toString()) : false
+            )
         } else {
             return elements.some((element) => this.checkPropertiesAgainstFilter(element, filter))
         }

--- a/tests/worker/ingestion/action-matcher.test.ts
+++ b/tests/worker/ingestion/action-matcher.test.ts
@@ -916,6 +916,11 @@ describe('ActionMatcher', () => {
                     selector: 'main > a[href="https://example.com/"]',
                 },
             ])
+            const actionDefinitionArraySelectorProp: Action = await createTestAction([
+                {
+                    properties: [{ type: 'element', key: 'selector', value: ['main h1.headline'] }],
+                },
+            ])
             const actionDefinitionEmptySelectorProp: Action = await createTestAction([
                 {
                     properties: [{ type: 'element', key: 'selector', value: '' }],
@@ -946,6 +951,7 @@ describe('ActionMatcher', () => {
             expect(await actionMatcher.match(event, undefined, elementsHrefProperNondirect)).toEqual([
                 actionDefinitionAnyDescendant,
                 actionDefinitionDirectHref,
+                actionDefinitionArraySelectorProp,
             ])
             expect(await actionMatcher.match(event, undefined, elementsHrefWrongClassNondirect)).toEqual([
                 actionDefinitionDirectHref,
@@ -953,6 +959,7 @@ describe('ActionMatcher', () => {
             expect(await actionMatcher.match(event, undefined, elementsHrefProperDirect)).toEqual([
                 actionDefinitionAnyDescendant,
                 actionDefinitionDirectDescendant,
+                actionDefinitionArraySelectorProp,
             ])
         })
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/plugin-server/issues/566 for good. Property filters save values into an array these days, which was accounted for in other matching paths, but not in selector matching.

## Checklist

-   [x] Jest tests
