### PR TITLE
Set isIdentified only when aliasing actually occurs

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -317,11 +317,8 @@ export class EventsProcessor {
         }
         if (event === '$create_alias') {
             await this.alias(properties['alias'], distinctId, teamId, false)
-        } else if (event === '$identify') {
-            if (properties['$anon_distinct_id']) {
-                await this.alias(properties['$anon_distinct_id'], distinctId, teamId)
-            }
-            await this.setIsIdentified(teamId, distinctId)
+        } else if (event === '$identify' && properties['$anon_distinct_id']) {
+            await this.alias(properties['$anon_distinct_id'], distinctId, teamId)
         }
     }
 
@@ -399,6 +396,10 @@ export class EventsProcessor {
                     otherPersonDistinctId: previousDistinctId,
                 })
             }
+        }
+
+        if (shouldIdentifyPerson) {
+            await this.setIsIdentified(teamId, distinctId)
         }
     }
 

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -333,6 +333,11 @@ export class EventsProcessor {
         retryIfFailed = true,
         totalMergeAttempts = 0
     ): Promise<void> {
+        // No reason to alias person against itself. Done by posthog-js-lite when updating user properties
+        if (previousDistinctId === distinctId) {
+            return
+        }
+
         const oldPerson = await this.db.fetchPerson(teamId, previousDistinctId)
         const newPerson = await this.db.fetchPerson(teamId, distinctId)
 

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -347,10 +347,7 @@ export class EventsProcessor {
                     await this.alias(previousDistinctId, distinctId, teamId, shouldIdentifyPerson, false)
                 }
             }
-            return
-        }
-
-        if (!oldPerson && newPerson) {
+        } else if (!oldPerson && newPerson) {
             try {
                 await this.db.addDistinctId(newPerson, previousDistinctId)
                 // Catch race case when somebody already added this distinct_id between .get and .addDistinctId
@@ -361,10 +358,7 @@ export class EventsProcessor {
                     await this.alias(previousDistinctId, distinctId, teamId, shouldIdentifyPerson, false)
                 }
             }
-            return
-        }
-
-        if (!oldPerson && !newPerson) {
+        } else if (!oldPerson && !newPerson) {
             try {
                 await this.db.createPerson(
                     DateTime.utc(),
@@ -383,10 +377,7 @@ export class EventsProcessor {
                     await this.alias(previousDistinctId, distinctId, teamId, shouldIdentifyPerson, false)
                 }
             }
-            return
-        }
-
-        if (oldPerson && newPerson && oldPerson.id !== newPerson.id) {
+        } else if (oldPerson && newPerson && oldPerson.id !== newPerson.id) {
             // $create_alias is an explicit call to merge 2 users, so we'll merge anything
             // for $identify, we'll not merge a user who's already identified into anyone else
             const isIdentifyCallToMergeAnIdentifiedUser = shouldIdentifyPerson && oldPerson.is_identified

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -50,7 +50,9 @@ export async function createPerson(
 
 export type ReturnWithHub = { hub?: Hub; closeHub?: () => Promise<void> }
 
-export const getEventsByPerson = async (hub: Hub) => {
+type EventsByPerson = [string[], string[]]
+
+export const getEventsByPerson = async (hub: Hub): Promise<EventsByPerson[]> => {
     // Helper function to retrieve events paired with their associated distinct
     // ids
     const persons = await hub.db.fetchPersons()
@@ -66,7 +68,7 @@ export const getEventsByPerson = async (hub: Hub) => {
                     .filter((event) => distinctIds.includes(event.distinct_id))
                     .sort((e1, e2) => new Date(e1.timestamp).getTime() - new Date(e2.timestamp).getTime())
                     .map((event) => event.event),
-            ] as const
+            ] as EventsByPerson
         })
     )
 }

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -1409,7 +1409,7 @@ export const createProcessEventTests = (
         await createPerson(hub, team, ['anonymous_id'])
 
         await processEvent(
-            'new_distinct_id',
+            'anonymous_id',
             '',
             '',
             {
@@ -1542,7 +1542,9 @@ export const createProcessEventTests = (
 
             const anonymousId = 'anonymous_id'
             const initialDistinctId = 'initial_distinct_id'
-            const newDistinctId = 'new_distinct_id'
+
+            const p2DistinctId = 'p2_distinct_id'
+            const p2NewDistinctId = 'new_distinct_id'
 
             // Play out a sequence of events that should result in two users being
             // identified, with the first to events associated with one user, and
@@ -1551,9 +1553,9 @@ export const createProcessEventTests = (
             await identify(hub, initialDistinctId)
             await capture(hub, 'event 2')
 
-            state.currentDistinctId = newDistinctId
+            state.currentDistinctId = p2DistinctId
             await capture(hub, 'event 3')
-            await identify(hub, newDistinctId)
+            await identify(hub, p2NewDistinctId)
             await capture(hub, 'event 4')
 
             // Let's also make sure that we do not alias when switching back to
@@ -1568,7 +1570,10 @@ export const createProcessEventTests = (
                     [anonymousId, initialDistinctId],
                     ['event 1', '$identify', 'event 2', '$identify'],
                 ],
-                [[newDistinctId], ['event 3', '$identify', 'event 4']],
+                [
+                    [p2DistinctId, p2NewDistinctId],
+                    ['event 3', '$identify', 'event 4'],
+                ],
             ])
 
             // Make sure the persons are identified
@@ -1588,7 +1593,9 @@ export const createProcessEventTests = (
 
             const anonymousId = 'anonymous_id'
             const initialDistinctId = 'initial_distinct_id'
-            const newDistinctId = 'new_distinct_id'
+
+            const p2DistinctId = 'p2_distinct_id'
+            const p2NewDistinctId = 'new_distinct_id'
 
             // Play out a sequence of events that should result in two users being
             // identified, with the first to events associated with one user, and
@@ -1596,9 +1603,9 @@ export const createProcessEventTests = (
             await identify(hub, initialDistinctId)
             await capture(hub, 'event 2')
 
-            state.currentDistinctId = newDistinctId
+            state.currentDistinctId = p2DistinctId
             await capture(hub, 'event 3')
-            await identify(hub, newDistinctId)
+            await identify(hub, p2NewDistinctId)
             await capture(hub, 'event 4')
 
             // Let's also make sure that we do not alias when switching back to
@@ -1613,7 +1620,10 @@ export const createProcessEventTests = (
                     [initialDistinctId, anonymousId],
                     ['$identify', 'event 2', '$identify'],
                 ],
-                [[newDistinctId], ['event 3', '$identify', 'event 4']],
+                [
+                    [p2DistinctId, p2NewDistinctId],
+                    ['event 3', '$identify', 'event 4'],
+                ],
             ])
 
             // Make sure the persons are identified


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/posthog/issues/6116 by not setting `is_identified` when not updating identities (e.g. when updating properties)

This was causing issues after https://github.com/PostHog/plugin-server/pull/576 as users who updated props on anonymous users would run into issues when logging in/signing up creating new users.

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [x] Jest tests
