### PR TITLE
Add simple ingestion support for groups

### DIFF
--- a/src/config/kafka-topics.ts
+++ b/src/config/kafka-topics.ts
@@ -5,3 +5,4 @@ export const KAFKA_SESSION_RECORDING_EVENTS = 'clickhouse_session_recording_even
 export const KAFKA_EVENTS_PLUGIN_INGESTION = 'events_plugin_ingestion'
 export const KAFKA_PLUGIN_LOG_ENTRIES = 'plugin_log_entries'
 export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = 'events_dead_letter_queue'
+export const KAFKA_GROUPS = 'clickhouse_groups'

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,6 +500,15 @@ export interface ClickHousePerson {
     timestamp: string
 }
 
+/** Clickhouse Group model */
+export interface ClickhouseGroup {
+    group_type_index: number
+    group_key: string
+    created_at: string
+    team_id: number
+    group_properties: string
+}
+
 /** Usable PersonDistinctId model. */
 export interface PersonDistinctId {
     id: number
@@ -710,3 +719,5 @@ export type PluginFunction = 'onEvent' | 'processEvent' | 'onSnapshot' | 'plugin
 export enum CeleryTriggeredJobOperation {
     Start = 'start',
 }
+
+export type GroupTypeToColumnIndex = Record<string, number>

--- a/src/utils/db/db.ts
+++ b/src/utils/db/db.ts
@@ -4,16 +4,17 @@ import { captureException } from '@sentry/node'
 import { Pool as GenericPool } from 'generic-pool'
 import { StatsD } from 'hot-shots'
 import Redis from 'ioredis'
-import { KafkaMessage, ProducerRecord } from 'kafkajs'
+import { ProducerRecord } from 'kafkajs'
 import { DateTime } from 'luxon'
 import { Pool, PoolClient, QueryConfig, QueryResult, QueryResultRow } from 'pg'
 
-import { KAFKA_PERSON_UNIQUE_ID, KAFKA_PLUGIN_LOG_ENTRIES } from '../../config/kafka-topics'
+import { KAFKA_GROUPS, KAFKA_PERSON_UNIQUE_ID, KAFKA_PLUGIN_LOG_ENTRIES } from '../../config/kafka-topics'
 import {
     Action,
     ActionEventPair,
     ActionStep,
     ClickHouseEvent,
+    ClickhouseGroup,
     ClickHousePerson,
     ClickHousePersonDistinctId,
     Cohort,
@@ -24,6 +25,7 @@ import {
     ElementGroup,
     Event,
     EventDefinitionType,
+    GroupTypeToColumnIndex,
     Hook,
     Person,
     PersonDistinctId,
@@ -38,6 +40,7 @@ import {
     RawPerson,
     SessionRecordingEvent,
     Team,
+    TeamId,
     TimestampFormat,
 } from '../../types'
 import { instrumentQuery } from '../metrics'
@@ -122,6 +125,9 @@ export class DB {
 
     /** A buffer for Postgres logs to prevent too many log insert ueries */
     postgresLogsWrapper: PostgresLogsWrapper
+
+    /** How many unique group types to allow per team */
+    MAX_GROUP_TYPES_PER_TEAM = 5
 
     constructor(
         postgres: Pool,
@@ -390,7 +396,7 @@ export class DB {
                 FINAL
                 GROUP BY team_id, id
                 HAVING max(is_deleted)=0
-            )            
+            )
             `
             return (await this.clickhouseQuery(query)).data.map((row) => {
                 const { 'person_max._timestamp': _discard1, 'person_max.id': _discard2, ...rest } = row
@@ -415,8 +421,8 @@ export class DB {
     public async fetchPerson(teamId: number, distinctId: string): Promise<Person | undefined> {
         const selectResult = await this.postgresQuery(
             `SELECT
-                posthog_person.id, posthog_person.created_at, posthog_person.team_id, posthog_person.properties, 
-                posthog_person.properties_last_updated_at, posthog_person.properties_last_operation, posthog_person.is_user_id, posthog_person.is_identified, 
+                posthog_person.id, posthog_person.created_at, posthog_person.team_id, posthog_person.properties,
+                posthog_person.properties_last_updated_at, posthog_person.properties_last_operation, posthog_person.is_user_id, posthog_person.is_identified,
                 posthog_person.uuid, posthog_persondistinctid.team_id AS persondistinctid__team_id,
                 posthog_persondistinctid.distinct_id AS persondistinctid__distinct_id
             FROM posthog_person
@@ -1140,5 +1146,79 @@ export class DB {
             [id, user_id, label, value, created_at.toISOString()],
             'createPersonalApiKey'
         )
+    }
+
+    public async fetchGroupTypes(teamId: TeamId): Promise<GroupTypeToColumnIndex> {
+        const { rows } = await this.postgresQuery(
+            `SELECT * FROM posthog_grouptypemapping WHERE team_id = $1`,
+            [teamId],
+            'fetchGroupTypes'
+        )
+
+        const result: GroupTypeToColumnIndex = {}
+
+        for (const row of rows) {
+            result[row.group_type] = row.group_type_index
+        }
+
+        return result
+    }
+
+    public async insertGroupType(teamId: TeamId, groupType: string, index: number): Promise<number | null> {
+        if (index >= this.MAX_GROUP_TYPES_PER_TEAM) {
+            return null
+        }
+
+        const insertGroupTypeResult = await this.postgresQuery(
+            `INSERT INTO posthog_grouptypemapping (group_type, group_type_index, team_id)
+            VALUES ($1, $2, $3)
+            ON CONFLICT DO NOTHING
+            RETURNING group_type_index`,
+            [groupType, index, teamId],
+            'upsertGroupType'
+        )
+
+        if (insertGroupTypeResult.rows.length == 0) {
+            return await this.insertGroupType(teamId, groupType, index + 1)
+        }
+
+        return insertGroupTypeResult.rows[0].group_type_index
+    }
+
+    public async upsertGroup(
+        teamId: TeamId,
+        groupTypeIndex: number,
+        groupKey: string,
+        properties: Properties
+    ): Promise<void> {
+        if (this.kafkaProducer) {
+            await this.kafkaProducer.queueMessage({
+                topic: KAFKA_GROUPS,
+                messages: [
+                    {
+                        value: Buffer.from(
+                            JSON.stringify({
+                                group_type_index: groupTypeIndex,
+                                group_key: groupKey,
+                                team_id: teamId,
+                                group_properties: JSON.stringify(properties),
+                                created_at: castTimestampOrNow(
+                                    DateTime.utc(),
+                                    TimestampFormat.ClickHouseSecondPrecision
+                                ),
+                            })
+                        ),
+                    },
+                ],
+            })
+        }
+    }
+
+    // Used in tests
+    public async fetchGroups(): Promise<ClickhouseGroup[]> {
+        const query = `
+        SELECT group_type_index, group_key, created_at, team_id, group_properties FROM groups FINAL
+        `
+        return (await this.clickhouseQuery(query)).data as ClickhouseGroup[]
     }
 }

--- a/src/worker/ingestion/group-type-manager.ts
+++ b/src/worker/ingestion/group-type-manager.ts
@@ -1,4 +1,4 @@
-import { GroupTypeToColumnIndex,TeamId } from '../../types'
+import { GroupTypeToColumnIndex, TeamId } from '../../types'
 import { DB } from '../../utils/db/db'
 import { timeoutGuard } from '../../utils/db/utils'
 import { getByAge } from '../../utils/utils'

--- a/src/worker/ingestion/group-type-manager.ts
+++ b/src/worker/ingestion/group-type-manager.ts
@@ -1,0 +1,44 @@
+import { GroupTypeToColumnIndex,TeamId } from '../../types'
+import { DB } from '../../utils/db/db'
+import { timeoutGuard } from '../../utils/db/utils'
+import { getByAge } from '../../utils/utils'
+
+export class GroupTypeManager {
+    db: DB
+    groupTypesCache: Map<number, [GroupTypeToColumnIndex, number]>
+
+    constructor(db: DB) {
+        this.db = db
+        this.groupTypesCache = new Map()
+    }
+
+    public async fetchGroupTypes(teamId: TeamId): Promise<GroupTypeToColumnIndex> {
+        const cachedGroupTypes = getByAge(this.groupTypesCache, teamId)
+        if (cachedGroupTypes) {
+            return cachedGroupTypes
+        }
+
+        const timeout = timeoutGuard(`Still running "fetchGroupTypes". Timeout warning after 30 sec!`)
+        try {
+            const teamGroupTypes: GroupTypeToColumnIndex = await this.db.fetchGroupTypes(teamId)
+            this.groupTypesCache.set(teamId, [teamGroupTypes, Date.now()])
+            return teamGroupTypes
+        } finally {
+            clearTimeout(timeout)
+        }
+    }
+
+    public async fetchGroupTypeIndex(teamId: TeamId, groupType: string): Promise<number | null> {
+        const groupTypes = await this.fetchGroupTypes(teamId)
+
+        if (groupType in groupTypes) {
+            return groupTypes[groupType]
+        } else {
+            const response = await this.db.insertGroupType(teamId, groupType, Object.keys(groupTypes).length)
+            if (response !== null) {
+                this.groupTypesCache.delete(teamId)
+            }
+            return response
+        }
+    }
+}

--- a/src/worker/ingestion/groups.ts
+++ b/src/worker/ingestion/groups.ts
@@ -1,0 +1,19 @@
+import { Properties } from '@posthog/plugin-scaffold'
+
+import { TeamId } from '../../types'
+import { GroupTypeManager } from './group-type-manager'
+
+export async function addGroupProperties(
+    teamId: TeamId,
+    properties: Properties,
+    groupTypeManager: GroupTypeManager
+): Promise<Properties> {
+    for (const [groupType, groupIdentifier] of Object.entries(properties.$groups || {})) {
+        const columnIndex = await groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
+        if (columnIndex !== null) {
+            // :TODO: Update event column instead
+            properties[`$group_${columnIndex}`] = groupIdentifier
+        }
+    }
+    return properties
+}

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -684,11 +684,11 @@ export class EventsProcessor {
 
     // :TODO: Support _updating_ part of properties, not just setting everything at once.
     private async upsertGroup(teamId: number, properties: Properties): Promise<void> {
-        if (!properties['group_type'] || !properties['group_key']) {
+        if (!properties['$group_type'] || !properties['$group_key']) {
             return
         }
 
-        const { group_type: groupType, group_key: groupKey, $group_set: groupPropertiesToSet } = properties
+        const { $group_type: groupType, $group_key: groupKey, $group_set: groupPropertiesToSet } = properties
         const groupTypeIndex = await this.groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
 
         if (groupTypeIndex !== null) {

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -30,6 +30,8 @@ import {
 } from '../../utils/db/utils'
 import { status } from '../../utils/status'
 import { castTimestampOrNow, RaceConditionError, UUID, UUIDT } from '../../utils/utils'
+import { GroupTypeManager } from './group-type-manager'
+import { addGroupProperties } from './groups'
 import { PersonManager } from './person-manager'
 import { TeamManager } from './team-manager'
 
@@ -73,6 +75,7 @@ export class EventsProcessor {
     celery: Client
     teamManager: TeamManager
     personManager: PersonManager
+    groupTypeManager: GroupTypeManager
 
     constructor(pluginsServer: Hub) {
         this.pluginsServer = pluginsServer
@@ -82,6 +85,7 @@ export class EventsProcessor {
         this.celery = new Client(pluginsServer.db, pluginsServer.CELERY_DEFAULT_QUEUE)
         this.teamManager = pluginsServer.teamManager
         this.personManager = new PersonManager(pluginsServer)
+        this.groupTypeManager = new GroupTypeManager(pluginsServer.db)
     }
 
     public async processEvent(
@@ -522,8 +526,11 @@ export class EventsProcessor {
         await this.createPersonIfDistinctIdIsNew(teamId, distinctId, sentAt || DateTime.utc(), personUuid)
 
         properties = personInitialAndUTMProperties(properties)
+        properties = await addGroupProperties(teamId, properties, this.groupTypeManager)
 
-        if (properties['$set'] || properties['$set_once']) {
+        if (event === '$groupidentify') {
+            await this.upsertGroup(teamId, properties)
+        } else if (properties['$set'] || properties['$set_once']) {
             const updatedSetAndSetOnce = await this.updatePersonProperties(
                 teamId,
                 distinctId,
@@ -672,6 +679,20 @@ export class EventsProcessor {
             } catch (error) {
                 Sentry.captureException(error, { extra: { teamId, distinctId, sentAt, personUuid } })
             }
+        }
+    }
+
+    // :TODO: Support _updating_ part of properties, not just setting everything at once.
+    private async upsertGroup(teamId: number, properties: Properties): Promise<void> {
+        if (!properties['group_type'] || !properties['group_key']) {
+            return
+        }
+
+        const { group_type: groupType, group_key: groupKey, $set: groupPropertiesToSet } = properties
+        const groupTypeIndex = await this.groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
+
+        if (groupTypeIndex !== null) {
+            await this.db.upsertGroup(teamId, groupTypeIndex, groupKey, groupPropertiesToSet || {})
         }
     }
 }

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -688,7 +688,7 @@ export class EventsProcessor {
             return
         }
 
-        const { group_type: groupType, group_key: groupKey, $set: groupPropertiesToSet } = properties
+        const { group_type: groupType, group_key: groupKey, $group_set: groupPropertiesToSet } = properties
         const groupTypeIndex = await this.groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
 
         if (groupTypeIndex !== null) {

--- a/tests/helpers/clickhouse.ts
+++ b/tests/helpers/clickhouse.ts
@@ -24,4 +24,6 @@ export async function resetTestDatabaseClickhouse(extraServerConfig: Partial<Plu
     await clickhouse.querying('TRUNCATE session_recording_events_mv')
     await clickhouse.querying('TRUNCATE plugin_log_entries')
     await clickhouse.querying('TRUNCATE events_dead_letter_queue')
+    await clickhouse.querying('TRUNCATE groups')
+    await clickhouse.querying('TRUNCATE groups_mv')
 }

--- a/tests/helpers/kafka.ts
+++ b/tests/helpers/kafka.ts
@@ -4,6 +4,7 @@ import { defaultConfig, overrideWithEnv } from '../../src/config/config'
 import {
     KAFKA_EVENTS,
     KAFKA_EVENTS_PLUGIN_INGESTION,
+    KAFKA_GROUPS,
     KAFKA_PERSON,
     KAFKA_PERSON_UNIQUE_ID,
     KAFKA_PLUGIN_LOG_ENTRIES,
@@ -31,6 +32,7 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
     await createTopics(kafka, [
         KAFKA_EVENTS,
         KAFKA_EVENTS_PLUGIN_INGESTION,
+        KAFKA_GROUPS,
         KAFKA_SESSION_RECORDING_EVENTS,
         KAFKA_PERSON,
         KAFKA_PERSON_UNIQUE_ID,

--- a/tests/helpers/sql.ts
+++ b/tests/helpers/sql.ts
@@ -40,7 +40,7 @@ export async function resetTestDatabase(
     } catch {}
 
     await db.query(`
-        TRUNCATE TABLE 
+        TRUNCATE TABLE
             posthog_personalapikey,
             posthog_featureflag,
             posthog_annotation,
@@ -64,6 +64,7 @@ export async function resetTestDatabase(
             posthog_plugin,
             posthog_eventdefinition,
             posthog_propertydefinition,
+            posthog_grouptypemapping,
             posthog_team,
             posthog_organizationmembership,
             posthog_organization,

--- a/tests/shared/db.test.ts
+++ b/tests/shared/db.test.ts
@@ -81,10 +81,12 @@ describe('DB', () => {
 
         it('handles conflict by name when inserting', async () => {
             expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(0)
-            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(null)
-            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(null)
+            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(0)
+            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(0)
+            expect(await db.insertGroupType(2, 'foo', 0)).toEqual(1)
+            expect(await db.insertGroupType(2, 'foo', 0)).toEqual(1)
 
-            expect(await db.fetchGroupTypes(2)).toEqual({ group_name: 0 })
+            expect(await db.fetchGroupTypes(2)).toEqual({ group_name: 0, foo: 1 })
         })
     })
 })

--- a/tests/shared/db.test.ts
+++ b/tests/shared/db.test.ts
@@ -4,6 +4,8 @@ import { createHub } from '../../src/utils/db/hub'
 import { ActionManager } from '../../src/worker/ingestion/action-manager'
 import { resetTestDatabase } from '../helpers/sql'
 
+jest.mock('../../src/utils/status')
+
 describe('DB', () => {
     let hub: Hub
     let closeServer: () => Promise<void>
@@ -54,6 +56,35 @@ describe('DB', () => {
                     ],
                 },
             },
+        })
+    })
+
+    describe('fetchGroupTypes() and insertGroupType()', () => {
+        it('fetches group types that have been inserted', async () => {
+            expect(await db.fetchGroupTypes(2)).toEqual({})
+            expect(await db.insertGroupType(2, 'g0', 0)).toEqual(0)
+            expect(await db.insertGroupType(2, 'g1', 1)).toEqual(1)
+            expect(await db.fetchGroupTypes(2)).toEqual({ g0: 0, g1: 1 })
+        })
+
+        it('handles conflicting by index when inserting and limits', async () => {
+            expect(await db.insertGroupType(2, 'g0', 0)).toEqual(0)
+            expect(await db.insertGroupType(2, 'g1', 0)).toEqual(1)
+            expect(await db.insertGroupType(2, 'g2', 0)).toEqual(2)
+            expect(await db.insertGroupType(2, 'g3', 1)).toEqual(3)
+            expect(await db.insertGroupType(2, 'g4', 0)).toEqual(4)
+            expect(await db.insertGroupType(2, 'g5', 0)).toEqual(null)
+            expect(await db.insertGroupType(2, 'g6', 0)).toEqual(null)
+
+            expect(await db.fetchGroupTypes(2)).toEqual({ g0: 0, g1: 1, g2: 2, g3: 3, g4: 4 })
+        })
+
+        it('handles conflict by name when inserting', async () => {
+            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(0)
+            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(null)
+            expect(await db.insertGroupType(2, 'group_name', 0)).toEqual(null)
+
+            expect(await db.fetchGroupTypes(2)).toEqual({ group_name: 0 })
         })
     })
 })

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -2137,6 +2137,8 @@ export const createProcessEventTests = (
             )
 
             expect((await hub.db.fetchEvents()).length).toBe(1)
+            await delayUntilEventIngested(() => hub.db.fetchGroups(), 1)
+
             const [group] = await hub.db.fetchGroups()
 
             expect(group).toEqual({

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -2137,9 +2137,15 @@ export const createProcessEventTests = (
             )
 
             expect((await hub.db.fetchEvents()).length).toBe(1)
-            const groups = await hub.db.fetchGroups()
+            const [group] = await hub.db.fetchGroups()
 
-            expect(groups).toEqual({})
+            expect(group).toEqual({
+                group_key: 'org::5',
+                group_properties: JSON.stringify({ foo: 'bar' }),
+                group_type_index: 0,
+                team_id: 2,
+                created_at: expect.any(String),
+            })
         })
     }
 

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -2110,5 +2110,38 @@ export const createProcessEventTests = (
         })
     })
 
+    if (database == 'clickhouse') {
+        test('groupidentify', async () => {
+            await createPerson(hub, team, ['distinct_id1'])
+
+            await processEvent(
+                'distinct_id1',
+                '',
+                '',
+                {
+                    event: '$groupidentify',
+                    properties: {
+                        token: team.api_token,
+                        distinct_id: 'distinct_id1',
+                        group_type: 'organization',
+                        group_key: 'org::5',
+                        $group_set: {
+                            foo: 'bar',
+                        },
+                    },
+                } as any as PluginEvent,
+                team.id,
+                now,
+                now,
+                new UUIDT().toString()
+            )
+
+            expect((await hub.db.fetchEvents()).length).toBe(1)
+            const groups = await hub.db.fetchGroups()
+
+            expect(groups).toEqual({})
+        })
+    }
+
     return returned
 }

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -2123,8 +2123,8 @@ export const createProcessEventTests = (
                     properties: {
                         token: team.api_token,
                         distinct_id: 'distinct_id1',
-                        group_type: 'organization',
-                        group_key: 'org::5',
+                        $group_type: 'organization',
+                        $group_key: 'org::5',
                         $group_set: {
                             foo: 'bar',
                         },

--- a/tests/worker/ingestion/group-type-manager.test.ts
+++ b/tests/worker/ingestion/group-type-manager.test.ts
@@ -1,0 +1,129 @@
+import { mocked } from 'ts-jest/utils'
+
+import { Hub } from '../../../src/types'
+import { createHub } from '../../../src/utils/db/hub'
+import { GroupTypeManager } from '../../../src/worker/ingestion/group-type-manager'
+import { resetTestDatabase } from '../../helpers/sql'
+
+jest.mock('../../../src/utils/status')
+
+describe('GroupTypeManager()', () => {
+    let hub: Hub
+    let closeHub: () => Promise<void>
+    let groupTypeManager: GroupTypeManager
+
+    beforeEach(async () => {
+        ;[hub, closeHub] = await createHub()
+        await resetTestDatabase()
+        groupTypeManager = new GroupTypeManager(hub.db)
+
+        jest.spyOn(hub.db, 'postgresQuery')
+        jest.spyOn(hub.db, 'insertGroupType')
+    })
+    afterEach(async () => {
+        await closeHub()
+    })
+
+    describe('fetchGroupTypes()', () => {
+        it('fetches and caches the group types', async () => {
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:05').getTime())
+
+            let groupTypes = await groupTypeManager.fetchGroupTypes(2)
+            expect(groupTypes).toEqual({})
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:25').getTime())
+            await hub.db.insertGroupType(2, 'foo', 0)
+            await hub.db.insertGroupType(2, 'bar', 1)
+
+            mocked(hub.db.postgresQuery).mockClear()
+
+            groupTypes = await groupTypeManager.fetchGroupTypes(2)
+
+            expect(groupTypes).toEqual({})
+            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
+
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:36').getTime())
+
+            groupTypes = await groupTypeManager.fetchGroupTypes(2)
+
+            expect(groupTypes).toEqual({
+                foo: 0,
+                bar: 1,
+            })
+            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+        })
+
+        it('returns empty object if no groups are set up yet', async () => {
+            expect(await groupTypeManager.fetchGroupTypes(2)).toEqual({})
+        })
+    })
+
+    describe('fetchGroupTypeIndex()', () => {
+        it('fetches an already existing value', async () => {
+            await hub.db.insertGroupType(2, 'foo', 0)
+            await hub.db.insertGroupType(2, 'bar', 1)
+
+            mocked(hub.db.postgresQuery).mockClear()
+            mocked(hub.db.insertGroupType).mockClear()
+
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'foo')).toEqual(0)
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'bar')).toEqual(1)
+
+            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+            expect(hub.db.insertGroupType).toHaveBeenCalledTimes(0)
+        })
+
+        it('inserts value if it does not exist yet at next index, resets cache', async () => {
+            await hub.db.insertGroupType(2, 'foo', 0)
+
+            mocked(hub.db.insertGroupType).mockClear()
+            mocked(hub.db.postgresQuery).mockClear()
+
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'second')).toEqual(1)
+
+            expect(hub.db.insertGroupType).toHaveBeenCalledTimes(1)
+            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(2)
+
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'third')).toEqual(2)
+            mocked(hub.db.postgresQuery).mockClear()
+
+            expect(await groupTypeManager.fetchGroupTypes(2)).toEqual({
+                foo: 0,
+                second: 1,
+                third: 2,
+            })
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'second')).toEqual(1)
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'third')).toEqual(2)
+
+            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+        })
+
+        it('handles raciness for inserting', async () => {
+            expect(await groupTypeManager.fetchGroupTypes(2)).toEqual({})
+
+            await hub.db.insertGroupType(2, 'foo', 0) // Emulate another thread inserting foo
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'second')).toEqual(1)
+            expect(await groupTypeManager.fetchGroupTypes(2)).toEqual({
+                foo: 0,
+                second: 1,
+            })
+        })
+
+        it('returns null once limit is met', async () => {
+            await hub.db.insertGroupType(2, 'g0', 0)
+            await hub.db.insertGroupType(2, 'g1', 1)
+            await hub.db.insertGroupType(2, 'g2', 2)
+            await hub.db.insertGroupType(2, 'g3', 3)
+            await hub.db.insertGroupType(2, 'g4', 4)
+
+            expect(await groupTypeManager.fetchGroupTypeIndex(2, 'new')).toEqual(null)
+            expect(await groupTypeManager.fetchGroupTypes(2)).toEqual({
+                g0: 0,
+                g1: 1,
+                g2: 2,
+                g3: 3,
+                g4: 4,
+            })
+        })
+    })
+})

--- a/tests/worker/ingestion/groups.test.ts
+++ b/tests/worker/ingestion/groups.test.ts
@@ -1,0 +1,48 @@
+import { addGroupProperties } from '../../../src/worker/ingestion/groups'
+
+describe('addGroupProperties()', () => {
+    let mockGroupTypeManager: any
+
+    beforeEach(() => {
+        const lookup: Record<string, number | null> = {
+            organization: 0,
+            project: 1,
+            foobar: null,
+        }
+        mockGroupTypeManager = {
+            fetchGroupTypeIndex: jest.fn().mockImplementation((teamId, key) => lookup[key]),
+        }
+    })
+
+    it('does nothing if no group properties', async () => {
+        expect(await addGroupProperties(2, { foo: 'bar' }, mockGroupTypeManager)).toEqual({ foo: 'bar' })
+
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).not.toHaveBeenCalled()
+    })
+
+    it('sets group properties as needed', async () => {
+        const properties = {
+            foo: 'bar',
+            $groups: {
+                organization: 'PostHog',
+                project: 'web',
+                foobar: 'afsafa',
+            },
+        }
+
+        expect(await addGroupProperties(2, properties, mockGroupTypeManager)).toEqual({
+            foo: 'bar',
+            $groups: {
+                organization: 'PostHog',
+                project: 'web',
+                foobar: 'afsafa',
+            },
+            $group_0: 'PostHog',
+            $group_1: 'web',
+        })
+
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 'organization')
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 'project')
+        expect(mockGroupTypeManager.fetchGroupTypeIndex).toHaveBeenCalledWith(2, 'foobar')
+    })
+})


### PR DESCRIPTION
## Changes

Initial support for groups added here. Very much inspired by the original PR.

Some gotchas: 
- Group rows are created on $groupidentify events, not when $group keys are passed. We'll iterate this as needed.
- Depends on https://github.com/PostHog/posthog/pull/6462 for tests as well

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [x] Jest tests
