### PR TITLE
be less picky with date formats

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -197,7 +197,7 @@ export class EventsProcessor {
                     Sentry.captureException(error, { extra: { data, now, sentAt } })
                 }
             }
-            return DateTime.fromISO(data['timestamp'])
+            return DateTime.fromISO(new Date(data['timestamp']).toISOString())
         }
         if (data['offset']) {
             return now.minus(Duration.fromMillis(data['offset']))

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -197,7 +197,7 @@ export class EventsProcessor {
                     Sentry.captureException(error, { extra: { data, now, sentAt } })
                 }
             }
-            return DateTime.fromISO(new Date(data['timestamp']).toISOString())
+            return DateTime.fromJSDate(new Date(data['timestamp']))
         }
         if (data['offset']) {
             return now.minus(Duration.fromMillis(data['offset']))


### PR DESCRIPTION
## Changes

_Please describe._

Would be good to add tests. I just wanted to open this before I forget.

We can be a lot less picky with dates if we use JS' `Date` to parse timestamps before casting to Luxon's DateTime.

e.g. DateTime can't handle `2021-06-03 13:08:19.795000` (ClickHouse timestamp) but JS dates can. 

We seem to already do this a few lines earlier.

This bit me recently btw, and from some Metabase analysis, seems like it bites a lot of users too. This won't throw, it just will return the UNIX epoch, and **a lot** of our events in CH have timestamp set to 01-01-1970. This can help with a lot of those probably. 

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
