### PR TITLE
Remove unused person creation path

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -211,28 +211,9 @@ export class EventsProcessor {
         properties: Properties,
         propertiesOnce: Properties
     ): Promise<Properties> {
-        let personFound = await this.db.fetchPerson(teamId, distinctId)
+        const personFound = await this.db.fetchPerson(teamId, distinctId)
         if (!personFound) {
-            try {
-                personFound = await this.db.createPerson(
-                    DateTime.utc(),
-                    properties,
-                    teamId,
-                    null,
-                    false,
-                    new UUIDT().toString(),
-                    [distinctId]
-                )
-            } catch {
-                // Catch race condition where in between getting and creating,
-                // another request already created this person
-                personFound = await this.db.fetchPerson(teamId, distinctId)
-            }
-        }
-        if (!personFound) {
-            throw new Error(
-                `Could not find person with distinct id "${distinctId}" in team "${teamId}", even after trying to insert them`
-            )
+            throw new Error(`Could not find person with distinct id "${distinctId}" in team "${teamId}"`)
         }
 
         // Figure out which properties we are actually setting

--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -213,7 +213,9 @@ export class EventsProcessor {
     ): Promise<Properties> {
         const personFound = await this.db.fetchPerson(teamId, distinctId)
         if (!personFound) {
-            throw new Error(`Could not find person with distinct id "${distinctId}" in team "${teamId}"`)
+            throw new Error(
+                `Could not find person with distinct id "${distinctId}" in team "${teamId}" to update properties`
+            )
         }
 
         // Figure out which properties we are actually setting
@@ -249,23 +251,9 @@ export class EventsProcessor {
     }
 
     private async setIsIdentified(teamId: number, distinctId: string, isIdentified = true): Promise<void> {
-        let personFound = await this.db.fetchPerson(teamId, distinctId)
+        const personFound = await this.db.fetchPerson(teamId, distinctId)
         if (!personFound) {
-            try {
-                personFound = await this.db.createPerson(
-                    DateTime.utc(),
-                    {},
-                    teamId,
-                    null,
-                    true,
-                    new UUIDT().toString(),
-                    [distinctId]
-                )
-            } catch {
-                // Catch race condition where in between getting and creating,
-                // another request already created this person
-                personFound = await this.db.fetchPerson(teamId, distinctId)
-            }
+            throw new Error(`Could not find person with distinct id "${distinctId}" in team "${teamId}" to identify`)
         }
         if (personFound && !personFound.is_identified) {
             await this.db.updatePerson(personFound, { is_identified: isIdentified })


### PR DESCRIPTION
## Changes

Goal: making future changes / refactor easier.
We always have a person at this point, because the private `updatePersonProperties` is only called in `capture` where we have `createPersonIfDistinctIdIsNew` beforehand.

Same story for `setIdentified` at that point we should have a person already and if we don't throwing might be better than creating a person with no props nor other info, to make debugging easier.


## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
