### PR TITLE
Silence distinct ID conflict Sentry errors

### DIFF
--- a/src/worker/ingestion/process-event.ts
+++ b/src/worker/ingestion/process-event.ts
@@ -670,7 +670,9 @@ export class EventsProcessor {
             try {
                 await this.db.createPerson(sentAt, {}, teamId, null, false, personUuid.toString(), [distinctId])
             } catch (error) {
-                Sentry.captureException(error, { extra: { teamId, distinctId, sentAt, personUuid } })
+                if (!error.message || !error.message.includes('duplicate key value violates unique constraint')) {
+                    Sentry.captureException(error, { extra: { teamId, distinctId, sentAt, personUuid } })
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes

I added this bit of error logging to help debug some things in the past but now it leads to Sentry spamming due to a very normal event (distinct id conflicts).

https://sentry.io/organizations/posthog/issues/2454986618/?project=5592816&query=is%3Aunresolved&statsPeriod=14d

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
