### PR TITLE
Event to have original passed set and set-once properties

### DIFF
--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -419,7 +419,12 @@ export const createProcessEventTests = (
         expect(events[1].properties.$set).toEqual({
             utm_medium: 'instagram',
         })
-        expect(events[1].properties.$set_once).toBeUndefined()
+        expect(events[1].properties.$set_once).toEqual({
+            $initial_browser: 'Firefox',
+            $initial_browser_version: 80,
+            $initial_utm_medium: 'instagram',
+            $initial_current_url: 'https://test.com/pricing',
+        })
 
         const [person] = persons
         const distinctIds = await hub.db.fetchDistinctIdValues(person)

--- a/tests/shared/process-event.ts
+++ b/tests/shared/process-event.ts
@@ -446,7 +446,7 @@ export const createProcessEventTests = (
             expect(event.elements_hash).toEqual('0679137c0cd2408a2906839143e7a71f')
         }
 
-        // Don't update any props, set and set_once should be undefined
+        // Don't update any props, set and set_once should be what was sent
         await processEvent(
             '2',
             '127.0.0.1',
@@ -474,8 +474,14 @@ export const createProcessEventTests = (
 
         events = await hub.db.fetchEvents()
 
-        expect(events[2].properties.$set).toBeUndefined()
-        expect(events[2].properties.$set_once).toBeUndefined()
+        expect(events[2].properties.$set).toEqual({
+            utm_medium: 'instagram',
+        })
+        expect(events[2].properties.$set_once).toEqual({
+            $initial_browser: 'Firefox',
+            $initial_utm_medium: 'instagram',
+            $initial_current_url: 'https://test.com/pricing',
+        })
 
         team = await getFirstTeam(hub)
 


### PR DESCRIPTION
## Changes

Currently we store the user properties we changed only on the events in ClickHouse.

If we store all the properties that were sent (set) with the event we'll have a much easier time debugging if we messed up somehow as we'll have all the data to be able to recompute things.

I believe this will also make it easier for users to understand what's happening. We store events in order of timestamps in the events page, but we might ingest them out of order. Imagine two events set a certain value, but we ingested the older event later, we would only see the set on the newer event as that's what was ingested first and changed the value.

This change was originally added in https://github.com/PostHog/plugin-server/pull/558

> I'm now checking which properties we are actually updating and only storing those against the event. Should massively reduce the amount of data we need to store in events, plus the amount of data we're sending to Postgres to update the user

## Checklist

-   [ ] Updated Settings section in README.md, if settings are affected
-   [ ] Jest tests
